### PR TITLE
Allow empty introduced commit fields.

### DIFF
--- a/docker/worker/testdata/BLAH-127.yaml
+++ b/docker/worker/testdata/BLAH-127.yaml
@@ -1,0 +1,16 @@
+id: BLAH-127
+package:
+  name: blah.com/package
+  ecosystem: golang
+summary: A vulnerability
+details: |
+  Blah blah blah
+  Blah
+severity: HIGH
+affects:
+  ranges:
+  - type: GIT
+    repo: https://osv-test/repo/url
+    fixed: 8d8242f545e9cec3e6d0d2e3f5bde8be1c659735
+references:
+- https://ref.com/ref

--- a/docker/worker/testdata/expected_127.diff
+++ b/docker/worker/testdata/expected_127.diff
@@ -1,0 +1,19 @@
+diff --git a/BLAH-127.yaml b/BLAH-127.yaml
+index 915f291..c6a4223 100644
+--- a/BLAH-127.yaml
++++ b/BLAH-127.yaml
+@@ -12,5 +12,14 @@ affects:
+   - type: GIT
+     repo: https://osv-test/repo/url
+     fixed: 8d8242f545e9cec3e6d0d2e3f5bde8be1c659735
++  - type: GIT
++    repo: https://osv-test/repo/url
++    fixed: b9b3fd4732695b83c3068b7b6a14bb372ec31f98
++  versions:
++  - branch-v0.1.1
++  - branch_1_cherrypick_regress
++  - v0.1
++  - v0.1.1
+ references:
+ - https://ref.com/ref
++modified: '2021-01-01T00:00:00Z'

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -358,8 +358,10 @@ class TaskRunner:
         if affected_range.type != vulnerability_pb2.AffectedRange.GIT:
           continue
 
-        range_collectors[affected_range.repo].add(affected_range.introduced,
-                                                  affected_range.fixed)
+        # Convert empty values ('') to None.
+        introduced = affected_range.introduced or None
+        fixed = affected_range.fixed or None
+        range_collectors[affected_range.repo].add(introduced, fixed)
 
       for affected_range in vulnerability.affects.ranges:
         # Go through existing provided ranges to find additional ranges (via

--- a/lib/osv/impact.py
+++ b/lib/osv/impact.py
@@ -167,8 +167,8 @@ def get_affected_range(repo, regress_commits, fix_commits):
       if equivalent_regress_commit:
         break
 
+    # If regress_commits is provided, then we should find an equivalent.
     if not equivalent_regress_commit and regress_commits:
-      # Allow empty regress_commits.
       continue
 
     # Get the latest equivalent commit in the fix range.


### PR DESCRIPTION
Assume all commits prior to the fix are vulnerable.