### PR TITLE
Improve CVE version extraction.

### DIFF
--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -64,6 +64,10 @@ func main() {
 		log.Printf("Valid versions = %v\n", validVersions)
 
 		v := vulns.FromCVE(cve, pkg, "PyPI", "ECOSYSTEM", validVersions)
+		if len(v.Affects.Ranges) == 0 {
+			log.Printf("No affected versions detected.")
+		}
+
 		data, err := yaml.Marshal(v)
 		if err != nil {
 			log.Fatalf("Failed to marshal YAML: %v", err)

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -78,13 +78,19 @@ func versionIndex(validVersions []string, version string) int {
 }
 
 func nextVersion(validVersions []string, version string) string {
-	idx := versionIndex(validVersions, version) + 1
-	if idx < len(validVersions) {
-		return validVersions[idx]
+	idx := versionIndex(validVersions, version)
+	if idx == -1 {
+		log.Printf("Warning: %s is not a valid version", version)
+		return ""
 	}
 
-	log.Printf("Warning: %s is not a valid version", version)
-	return ""
+	idx += 1
+	if idx >= len(validVersions) {
+		log.Printf("Warning: %s does not have a version that comes after.", version)
+		return ""
+	}
+
+	return validVersions[idx]
 }
 
 func processExtractedVersion(version string) string {

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -15,7 +15,9 @@
 package cves
 
 import (
+	"log"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -62,6 +64,74 @@ func extractGitHubCommit(link string) *FixCommit {
 	}
 }
 
+func hasVersion(validVersions []string, version string) bool {
+	return versionIndex(validVersions, version) != -1
+}
+
+func versionIndex(validVersions []string, version string) int {
+	for i, cur := range validVersions {
+		if cur == version {
+			return i
+		}
+	}
+	return -1
+}
+
+func nextVersion(validVersions []string, version string) string {
+	idx := versionIndex(validVersions, version) + 1
+	if idx < len(validVersions) {
+		return validVersions[idx]
+	}
+
+	log.Printf("Warning: %s is not a valid version", version)
+	return ""
+}
+
+func processExtractedVersion(version string) string {
+	version = strings.Trim(version, ".")
+	// Version should contain at least a "." or a number.
+	if !strings.ContainsAny(version, ".") && !strings.ContainsAny(version, "0123456789") {
+		return ""
+	}
+
+	return version
+}
+
+func extractVersionsFromDescription(validVersions []string, description string) []AffectedVersion {
+	// Match:
+	//  - x.x.x before x.x.x
+	//  - x.x.x through x.x.x
+	//  - through x.x.x
+	//  - before x.x.x
+	pattern := regexp.MustCompile(`(?i)([\w.+\-]+)?\s+(through|before)\s+(?:version\s+)?([\w.+\-]+)`)
+	matches := pattern.FindAllStringSubmatch(description, -1)
+	if matches == nil {
+		return nil
+	}
+
+	var versions []AffectedVersion
+	for _, match := range matches {
+		// Trim periods that are part of sentences.
+		introduced := processExtractedVersion(match[1])
+		fixed := processExtractedVersion(match[3])
+		if match[2] == "through" {
+			// "Through" implies inclusive range, so the fixed version is the one that comes after.
+			fixed = nextVersion(validVersions, fixed)
+		}
+
+		if introduced == "" && fixed == "" {
+			continue
+		}
+
+		versions = append(versions, AffectedVersion{
+			Introduced: introduced,
+			Fixed:      fixed,
+		})
+	}
+
+	return versions
+}
+
 func ExtractVersionInfo(cve CVEItem, validVersions []string) VersionInfo {
 	v := VersionInfo{}
 	for _, reference := range cve.CVE.References.ReferenceData {
@@ -71,30 +141,55 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) VersionInfo {
 		}
 	}
 
+	gotVersions := false
 	for _, node := range cve.Configurations.Nodes {
 		if node.Operator != "OR" {
 			continue
 		}
 
-		// TODO: Also try to parse description as these are not always reliably set.
 		for _, match := range node.CPEMatch {
 			if !match.Vulnerable {
 				continue
 			}
 
-			if match.VersionStartIncluding != "" || match.VersionEndExcluding != "" {
-				if match.VersionStartExcluding != "" || match.VersionEndIncluding != "" {
-					// TODO: handle these by using validVersions.
-					continue
-				}
-
-				v.AffectedVersions = append(v.AffectedVersions, AffectedVersion{
-					// TODO: make sure these match validVersions.
-					Introduced: match.VersionStartIncluding,
-					Fixed:      match.VersionEndExcluding,
-				})
+			introduced := ""
+			fixed := ""
+			if match.VersionStartIncluding != "" {
+				introduced = match.VersionStartIncluding
+			} else if match.VersionStartExcluding != "" {
+				introduced = nextVersion(validVersions, match.VersionStartExcluding)
 			}
+
+			if match.VersionEndExcluding != "" {
+				fixed = match.VersionEndExcluding
+			} else if match.VersionEndIncluding != "" {
+				fixed = nextVersion(validVersions, match.VersionEndIncluding)
+			}
+
+			if introduced == "" && fixed == "" {
+				continue
+			}
+
+			if introduced != "" && !hasVersion(validVersions, introduced) {
+				log.Printf("Warning: %s is not a valid introduced version", introduced)
+			}
+
+			if fixed != "" && !hasVersion(validVersions, fixed) {
+				log.Printf("Warning: %s is not a valid fixed version", fixed)
+			}
+
+			gotVersions = true
+			v.AffectedVersions = append(v.AffectedVersions, AffectedVersion{
+				Introduced: introduced,
+				Fixed:      fixed,
+			})
 		}
 	}
+
+	if !gotVersions {
+		v.AffectedVersions = extractVersionsFromDescription(validVersions, EnglishDescription(cve.CVE))
+		log.Printf("Extracted versions from description = %+v", v.AffectedVersions)
+	}
+
 	return v
 }

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -57,15 +57,6 @@ func timestampToRFC3339(timestamp string) (string, error) {
 	return t.Format(time.RFC3339), nil
 }
 
-func hasVersion(validVersions []string, version string) bool {
-	for _, cur := range validVersions {
-		if cur == version {
-			return true
-		}
-	}
-	return false
-}
-
 func FromCVE(cve cves.CVEItem, pkg, ecosystem, versionType string, validVersions []string) *Vulnerability {
 	cveID := cve.CVE.CVEDataMeta.ID
 	v := Vulnerability{
@@ -105,14 +96,6 @@ func FromCVE(cve cves.CVEItem, pkg, ecosystem, versionType string, validVersions
 	}
 
 	for _, affected := range version.AffectedVersions {
-		if affected.Introduced != "" && !hasVersion(validVersions, affected.Introduced) {
-			log.Printf("Warning: %s is not a valid introduced version", affected.Introduced)
-		}
-
-		if affected.Fixed != "" && !hasVersion(validVersions, affected.Fixed) {
-			log.Printf("Warning: %s is not a valid fixed version", affected.Fixed)
-		}
-
 		v.Affects.Ranges = append(v.Affects.Ranges, AffectedRange{
 			Type:       versionType,
 			Introduced: affected.Introduced,


### PR DESCRIPTION
- Handle versionStartExcluding and versionEndIncluding by using
  the list of actual package versions to derive "introduced" and "fixed".
- Extract versions from description as a last resort.