### PR TITLE
vulnfeeds: Improve Python vuln matching.

### DIFF
--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -45,7 +45,7 @@ func loadFalsePositives(path string) map[string]bool {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		falsePositives[scanner.Text()] = true
+		falsePositives[strings.TrimSpace(scanner.Text())] = true
 	}
 	if err := scanner.Err(); err != nil {
 		log.Fatal("Failed to read lines: %v", err)
@@ -95,7 +95,8 @@ func main() {
 		}
 		log.Printf("Valid versions = %v\n", validVersions)
 
-		v, notes := vulns.FromCVE(cve, pkg, "PyPI", "ECOSYSTEM", validVersions)
+		id := "PYSEC-" + cve.CVE.CVEDataMeta.ID
+		v, notes := vulns.FromCVE(id, cve, pkg, "PyPI", "ECOSYSTEM", validVersions)
 		if len(v.Affects.Ranges) == 0 {
 			log.Printf("No affected versions detected.")
 		}

--- a/vulnfeeds/cves/cve.go
+++ b/vulnfeeds/cves/cve.go
@@ -44,6 +44,7 @@ type CVEItem struct {
 			Operator string `json:"operator"`
 			CPEMatch []struct {
 				Vulnerable            bool   `json:"vulnerable"`
+				CPE23URI              string `json:"cpe23Uri"`
 				VersionStartExcluding string `json:"versionStartExcluding"`
 				VersionStartIncluding string `json:"versionStartIncluding"`
 				VersionEndExcluding   string `json:"versionEndExcluding"`

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -218,3 +218,18 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (VersionInfo, []str
 	}
 	return v, notes
 }
+
+func CPEs(cve CVEItem) []string {
+	cpesMap := map[string]bool{}
+	for _, node := range cve.Configurations.Nodes {
+		for _, match := range node.CPEMatch {
+			cpesMap[match.CPE23URI] = true
+		}
+	}
+
+	var cpes []string
+	for cpe := range cpesMap {
+		cpes = append(cpes, cpe)
+	}
+	return cpes
+}

--- a/vulnfeeds/pypi/README.md
+++ b/vulnfeeds/pypi/README.md
@@ -5,7 +5,7 @@ For PyPI, we find package reference URLs by doing a BigQuery query on
 the public PyPI dataset.
 
 ```bash
-bq query --max_rows=10000000 --format=json --nouse_legacy_sql --flagfile=pypi_links.sql > pypi_links.json
+bq query --max_rows=10000000 --format=json --nouse_legacy_sql < pypi_links.sql > pypi_links.json
 ```
 
 However this includes packages that no longer exist or were deleted, so we check
@@ -16,5 +16,5 @@ to make sure any matches actually exist.
 We also extract all valid versions by doing:
 
 ```bash
-bq query --max_rows=10000000 --format=json --nouse_legacy_sql --flagfile=pypi_versions.sql > pypi_versions.json
+bq query --max_rows=10000000 --format=json --nouse_legacy_sql < pypi_versions.sql > pypi_versions.json
 ```

--- a/vulnfeeds/pypi/pypi.go
+++ b/vulnfeeds/pypi/pypi.go
@@ -198,6 +198,10 @@ func (p *PyPI) Matches(cve cves.CVEItem) string {
 	}
 
 	cpe := strings.Split(cpes[0], ":")
+	if len(cpe) < 5 {
+		return ""
+	}
+
 	vendorProduct := cpe[3] + "/" + cpe[4]
 	if pkgs, exists := p.vendorProductToPkg[vendorProduct]; exists {
 		for _, pkg := range pkgs {

--- a/vulnfeeds/pypi/pypi_links.sql
+++ b/vulnfeeds/pypi/pypi_links.sql
@@ -14,7 +14,7 @@
 
 # Remove duplicates and "Type, " prefixes.
 CREATE TEMP FUNCTION PROCESS_LINKS(val ARRAY<STRING>) AS ((
-  SELECT ARRAY_AGG(REGEXP_REPLACE(t.v, "^.*,\\s*", ""))
+  SELECT ARRAY_AGG(REGEXP_REPLACE(t.v, "^.*,\\s*", "") IGNORE NULLS)
   FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
 ));
 
@@ -45,6 +45,7 @@ return results;
 SELECT name,
 PROCESS_LINKS(ARRAY_CONCAT(
   ARRAY_AGG(DISTINCT home_page),
+  ARRAY_AGG(DISTINCT download_url),
   ARRAY_CONCAT_AGG(project_urls),
   ARRAY_CONCAT_AGG(EXTRACT_LINKS(name, description)))) as links
 FROM `bigquery-public-data.pypi.distribution_metadata`

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -42,7 +42,7 @@ type Vulnerability struct {
 		Versions []string        `json:"versions" yaml:"versions,omitempty"`
 	}
 	References []string               `json:"references" yaml:"references"`
-	Aliases    []string               `json:"aliases" yaml:"aliases"`
+	Aliases    []string               `json:"aliases,omitempty" yaml:"aliases,omitempty"`
 	Extra      map[string]interface{} `json:"extras,omitempty" yaml:"extra,omitempty"`
 	Modified   string                 `json:"modified" yaml:"modified"`
 	Created    string                 `json:"created" yaml:"created"`
@@ -57,15 +57,18 @@ func timestampToRFC3339(timestamp string) (string, error) {
 	return t.Format(time.RFC3339), nil
 }
 
-func FromCVE(cve cves.CVEItem, pkg, ecosystem, versionType string, validVersions []string) (*Vulnerability, []string) {
-	cveID := cve.CVE.CVEDataMeta.ID
+func FromCVE(id string, cve cves.CVEItem, pkg, ecosystem, versionType string, validVersions []string) (*Vulnerability, []string) {
+	var aliases []string
+	if id != cve.CVE.CVEDataMeta.ID {
+		aliases = append(aliases, cve.CVE.CVEDataMeta.ID)
+	}
+
 	v := Vulnerability{
-		// TODO: Generalize.
-		ID:       "PYSEC-" + cveID,
-		Summary:  "TODO",
+		ID:       id,
+		Summary:  fmt.Sprintf("Vulnerability in %s", pkg),
 		Details:  cves.EnglishDescription(cve.CVE),
 		Severity: cve.Impact.BaseMetricV3.CVSSV3.BaseSeverity,
-		Aliases:  []string{cveID},
+		Aliases:  aliases,
 	}
 	v.Package.Name = pkg
 	v.Package.Ecosystem = ecosystem


### PR DESCRIPTION
- Add a new heuristic to extract "vendor/product" from GitHub links
  and cross reference that against CPEs.

- Also fix a bug with PyPI link parsing.