### PR TITLE
Generalize affected ranges in Datastore.

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -183,7 +183,7 @@ class Importer:
       return
 
     for bug in osv.Bug.query(osv.Bug.status == osv.BugStatus.PROCESSED,
-                             osv.Bug.fixed == ''):
+                             osv.Bug.is_fixed == False):  # pylint: disable=singleton-comparison
       self._request_analysis(bug, source_repo, repo)
 
     # Re-compute existing Bugs for a period of time, as upstream changes may

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -194,7 +194,7 @@ class Importer:
 
     for bug in query:
       logging.info('Re-requesting impact for %s.', bug.key.id())
-      if not bug.fixed:
+      if not bug.is_fixed:
         # Previous query already requested impact tasks for unfixed bugs.
         continue
 

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -190,7 +190,6 @@ class ImporterTest(unittest.TestCase):
         id='2021-1337',
         project='proj',
         ecosystem='OSS-Fuzz',
-        fixed='',
         status=1,
         source_id='oss-fuzz:123',
         source_of_truth=osv.SourceOfTruth.SOURCE_REPO,
@@ -198,16 +197,19 @@ class ImporterTest(unittest.TestCase):
     osv.Bug(
         id='2021-1338',
         project='proj',
-        fixed='fix',
         source_id='source:OSV-2021-1338.yaml',
         status=1,
         source_of_truth=osv.SourceOfTruth.SOURCE_REPO,
-        timestamp=importer.utcnow()).put()
+        timestamp=importer.utcnow(),
+        affected_ranges=[{
+            'fixed': 'fix',
+            'repo_url': 'repo',
+            'type': 'GIT',
+        }]).put()
     osv.Bug(
         id='2021-1339',
         project='proj',
         ecosystem='OSS-Fuzz',
-        fixed='',
         status=1,
         source_id='oss-fuzz:124',
         source_of_truth=osv.SourceOfTruth.INTERNAL,

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -69,6 +69,12 @@ class ImporterTest(unittest.TestCase):
         id='2017-134',
         affected=['FILE5_29', 'FILE5_30'],
         affected_fuzzy=['5-29', '5-30'],
+        affected_ranges=[{
+            'type': 'GIT',
+            'repo_url': 'https://github.com/file/file.git',
+            'introduced': '17ee4cf670c363de8d2ea4a4897d7a699837873f',
+            'fixed': '19ccebafb7663c422c714e0c67fa4775abf91c43',
+        }],
         details=(
             'OSS-Fuzz report: '
             'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1064\n\n'
@@ -89,7 +95,6 @@ class ImporterTest(unittest.TestCase):
             'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1064'
         ],
         regressed='17ee4cf670c363de8d2ea4a4897d7a699837873f',
-        repo_url='https://github.com/file/file.git',
         search_indices=['file', '2017-134', '2017', '134'],
         severity='MEDIUM',
         sort_key='2017-0000134',

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -170,18 +170,27 @@ class ImpactTest(unittest.TestCase):
         {
             'affected':
                 ['branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1.1'],
-            'additional_commit_ranges': [{
-                'introduced_in': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-                'fixed_in': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98'
-            }, {
-                'introduced_in': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
-                'fixed_in': None
-            }],
             'affected_fuzzy': ['0-1-1', '1', '0-1-1'],
+            'affected_ranges': [{
+                'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
+            }, {
+                'fixed': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
+            }, {
+                'fixed': '',
+                'introduced': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
+            }],
             'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
             'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://repo.com/repo',
             'issue_id': '9001',
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'timestamp': datetime.datetime(2020, 1, 1),
             'source_id': 'oss-fuzz:123',
@@ -256,12 +265,18 @@ class ImpactTest(unittest.TestCase):
                 'branch_1_cherrypick_regress', 'v0.1.1', 'v0.2'
             ],
             'affected_fuzzy': ['0-1-1', '0-1-1', '1', '0-1-1', '0-2'],
-            'additional_commit_ranges': [],
+            'affected_ranges': [{
+                'fixed': 'b1c95a196f22d06fcf80df8c6691cd113d8fefff:'
+                         '36f0bd9549298b44f9ff2496c9dd1326b3a9d0e2',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
+            }],
             'fixed': ('b1c95a196f22d06fcf80df8c6691cd113d8fefff:'
                       '36f0bd9549298b44f9ff2496c9dd1326b3a9d0e2'),
             'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://repo.com/repo',
             'issue_id': '9001',
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'timestamp': datetime.datetime(2020, 1, 1),
             'source_id': 'oss-fuzz:123',
@@ -337,12 +352,18 @@ class ImpactTest(unittest.TestCase):
                 'branch_1_cherrypick_regress', 'v0.1.1', 'v0.2'
             ],
             'affected_fuzzy': ['0-1-1', '0-1-1', '1', '0-1-1', '0-2'],
-            'additional_commit_ranges': [],
+            'affected_ranges': [{
+                'fixed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd:'
+                         'b587c21c36a84e16cfc6b39eb68578d43b5281ad',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
+            }],
             'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
             'fixed': ('eefe8ec3f1f90d0e684890e810f3f21e8500a4cd:'
                       'b587c21c36a84e16cfc6b39eb68578d43b5281ad'),
-            'repo_url': 'https://repo.com/repo',
             'issue_id': '9001',
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'timestamp': datetime.datetime(2020, 1, 1),
             'source_id': 'oss-fuzz:123',
@@ -417,11 +438,20 @@ class ImpactTest(unittest.TestCase):
             'affected':
                 ['branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1.1'],
             'affected_fuzzy': ['0-1-1', '1', '0-1-1'],
-            'additional_commit_ranges': [],
+            'affected_ranges': [{
+                'fixed':
+                    '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                'introduced':
+                    'unknown:eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url':
+                    'https://repo.com/repo',
+                'type':
+                    'GIT'
+            }],
             'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
             'regressed': 'unknown:eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://repo.com/repo',
             'issue_id': '9001',
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'timestamp': datetime.datetime(2020, 1, 1),
             'source_id': 'oss-fuzz:123',
@@ -495,17 +525,26 @@ class ImpactTest(unittest.TestCase):
             'affected':
                 ['branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1.1'],
             'affected_fuzzy': ['0-1-1', '1', '0-1-1'],
-            'additional_commit_ranges': [{
-                'introduced_in': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-                'fixed_in': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98'
+            'affected_ranges': [{
+                'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
             }, {
-                'introduced_in': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
-                'fixed_in': None
+                'fixed': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
+            }, {
+                'fixed': '',
+                'introduced': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
             }],
             'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
             'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://repo.com/repo',
             'issue_id': '9001',
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'timestamp': datetime.datetime(2020, 1, 1),
             'source_id': 'oss-fuzz:123',
@@ -556,14 +595,21 @@ class ImpactTest(unittest.TestCase):
                 'branch_1_cherrypick_regress', 'v0.1.1', 'v0.2'
             ],
             'affected_fuzzy': ['0-1-1', '0-1-1', '1', '0-1-1', '0-2'],
-            'additional_commit_ranges': [{
-                'introduced_in': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
-                'fixed_in': None
+            'affected_ranges': [{
+                'fixed': '',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
+            }, {
+                'fixed': '',
+                'introduced': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
+                'repo_url': 'https://repo.com/repo',
+                'type': 'GIT'
             }],
             'fixed': '',
             'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://repo.com/repo',
             'issue_id': '9001',
+            'is_fixed': False,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'timestamp': datetime.datetime(2020, 1, 1),
             'source_id': 'oss-fuzz:123',
@@ -855,21 +901,31 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
-            'additional_commit_ranges': [{
-                'fixed_in': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
-                'introduced_in': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd'
+            'affected_ranges': [{
+                'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
             }, {
-                'fixed_in': '',
-                'introduced_in': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209'
+                'fixed': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }, {
+                'fixed': '',
+                'introduced': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
             }],
             'affected':
                 ['branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1.1'],
             'affected_fuzzy': ['0-1-1', '1', '0-1-1'],
             'details': 'Blah blah blah\nBlah\n',
             'ecosystem': 'golang',
-            'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+            'fixed': '',
             'has_affected': True,
             'issue_id': None,
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
             'public': None,
@@ -877,8 +933,7 @@ class UpdateTest(unittest.TestCase):
                 'https://ref.com/ref': 'WEB'
             },
             'reference_urls': ['https://ref.com/ref'],
-            'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://osv-test/repo/url',
+            'regressed': '',
             'search_indices': ['blah.com/package', 'BLAH-123', 'BLAH', '123'],
             'severity': 'HIGH',
             'sort_key': 'BLAH-0000123',
@@ -928,21 +983,31 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
-            'additional_commit_ranges': [{
-                'fixed_in': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
-                'introduced_in': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd'
-            }, {
-                'fixed_in': '',
-                'introduced_in': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209'
-            }],
             'affected':
                 ['branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1.1'],
             'affected_fuzzy': ['0-1-1', '1', '0-1-1'],
+            'affected_ranges': [{
+                'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }, {
+                'fixed': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }, {
+                'fixed': '',
+                'introduced': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }],
             'details': 'Blah blah blah\nBlah\n',
             'ecosystem': 'golang',
-            'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+            'fixed': '',
             'has_affected': True,
             'issue_id': None,
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
             'public': None,
@@ -951,7 +1016,6 @@ class UpdateTest(unittest.TestCase):
             },
             'reference_urls': ['https://ref.com/ref'],
             'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://osv-test/repo/url',
             'search_indices': ['blah.com/package', 'BLAH-124', 'BLAH', '124'],
             'severity': 'HIGH',
             'sort_key': 'BLAH-0000124',
@@ -998,19 +1062,27 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
-            'additional_commit_ranges': [{
-                'fixed_in': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
-                'introduced_in': ''
-            },],
             'affected': [
                 'branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1', 'v0.1.1'
             ],
             'affected_fuzzy': ['0-1-1', '1', '0-1', '0-1-1'],
+            'affected_ranges': [{
+                'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                'introduced': '',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }, {
+                'fixed': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
+                'introduced': '',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }],
             'details': 'Blah blah blah\nBlah\n',
             'ecosystem': 'golang',
-            'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+            'fixed': '',
             'has_affected': True,
             'issue_id': None,
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
             'public': None,
@@ -1019,7 +1091,6 @@ class UpdateTest(unittest.TestCase):
             },
             'reference_urls': ['https://ref.com/ref'],
             'regressed': '',
-            'repo_url': 'https://osv-test/repo/url',
             'search_indices': ['blah.com/package', 'BLAH-127', 'BLAH', '127'],
             'severity': 'HIGH',
             'sort_key': 'BLAH-0000127',
@@ -1078,21 +1149,31 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
-            'additional_commit_ranges': [{
-                'fixed_in': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
-                'introduced_in': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd'
-            }, {
-                'fixed_in': '',
-                'introduced_in': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209'
-            }],
             'affected':
                 ['branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1.1'],
             'affected_fuzzy': ['0-1-1', '1', '0-1-1'],
+            'affected_ranges': [{
+                'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }, {
+                'fixed': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
+                'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }, {
+                'fixed': '',
+                'introduced': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
+                'repo_url': 'https://osv-test/repo/url',
+                'type': 'GIT'
+            }],
             'details': 'Blah blah blah\nBlah\n',
             'ecosystem': 'golang',
-            'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+            'fixed': '',
             'has_affected': True,
             'issue_id': None,
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
             'public': None,
@@ -1100,8 +1181,7 @@ class UpdateTest(unittest.TestCase):
                 'https://ref.com/ref': 'WEB'
             },
             'reference_urls': ['https://ref.com/ref'],
-            'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-            'repo_url': 'https://osv-test/repo/url',
+            'regressed': '',
             'search_indices': ['blah.com/package', 'BLAH-126', 'BLAH', '126'],
             'severity': 'HIGH',
             'sort_key': 'BLAH-0000126',
@@ -1234,7 +1314,6 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
-            'additional_commit_ranges': [],
             'affected': [
                 '1.14.2', '1.15.0', '1.15.0rc1', '1.16.0', '1.16.0rc1',
                 '1.16.1', '1.16.1rc1', '1.17.0', '1.17.0rc1', '1.17.1',
@@ -1261,11 +1340,18 @@ class UpdateTest(unittest.TestCase):
                 '1-28-1', '1-29-0', '1-30-0', '1-30-0-rc1', '1-31-0-rc1',
                 '1-31-0-rc2'
             ],
+            'affected_ranges': [{
+                'fixed': '1.31.0',
+                'introduced': '1.14.2',
+                'repo_url': '',
+                'type': 'ECOSYSTEM'
+            }],
             'details': 'Blah blah blah\nBlah\n',
             'ecosystem': 'PyPI',
-            'fixed': None,
+            'fixed': '',
             'has_affected': True,
             'issue_id': None,
+            'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'grpcio',
             'public': None,
@@ -1273,8 +1359,7 @@ class UpdateTest(unittest.TestCase):
                 'https://ref.com/ref': 'WEB'
             },
             'reference_urls': ['https://ref.com/ref'],
-            'regressed': None,
-            'repo_url': None,
+            'regressed': '',
             'search_indices': ['grpcio', 'PYSEC-123', 'PYSEC', '123'],
             'severity': 'HIGH',
             'sort_key': 'PYSEC-0000123',

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -112,7 +112,7 @@ def bug_to_response(bug, detailed=False):
           'name': bug.project,
           'ecosystem': bug.ecosystem,
       },
-      'isFixed': bool(bug.fixed),
+      'isFixed': bug.is_fixed,
       'invalid': bug.status == osv.BugStatus.INVALID
   }
 
@@ -126,15 +126,13 @@ def bug_to_response(bug, detailed=False):
     response['details'] = bug.details
     response['severity'] = bug.severity
     response['references'] = bug.reference_urls
-    response['regressed'] = _get_commits(bug, [bug.regressed] + [
-        commit_range.introduced_in
-        for commit_range in bug.additional_commit_ranges
-    ])
+    response['regressed'] = _get_commits(
+        bug,
+        [affected_range.introduced for affected_range in bug.affected_ranges])
 
-    if bug.fixed:
-      response['fixed'] = _get_commits(bug, [bug.fixed] + [
-          commit_range.fixed_in for commit_range in bug.additional_commit_ranges
-      ])
+    if bug.is_fixed:
+      response['fixed'] = _get_commits(
+          bug, [affected_range.fixed for affected_range in bug.affected_ranges])
 
     if bug.status == osv.BugStatus.INVALID:
       response['regressed'] = [_to_commit(bug, 'INVALID')]

--- a/gcp/appengine/index.yaml
+++ b/gcp/appengine/index.yaml
@@ -77,9 +77,15 @@ indexes:
       - name: public
       - name: status
 
+  # TODO(ochang) remove after migration.
   - kind: Bug
     properties:
       - name: fixed
+      - name: status
+
+  - kind: Bug
+    properties:
+      - name: is_fixed
       - name: status
 
   - kind: Bug

--- a/lib/osv/types.py
+++ b/lib/osv/types.py
@@ -33,6 +33,14 @@ def _check_valid_severity(prop, value):
     raise ValueError('Invalid severity: ' + value)
 
 
+def _check_valid_range_type(prop, value):
+  """Check valid range type."""
+  del prop
+
+  if value not in ('GIT', 'SEMVER', 'ECOSYSTEM'):
+    raise ValueError('Invalid severity: ' + value)
+
+
 def utcnow():
   """For mocking."""
   return datetime.datetime.utcnow()
@@ -133,7 +141,7 @@ class PackageTagInfo(ndb.Model):
 class AffectedRange(ndb.Model):
   """Affected range."""
   # Type of range.
-  type = ndb.StringProperty()
+  type = ndb.StringProperty(validator=_check_valid_range_type)
   # Repo URL.
   repo_url = ndb.StringProperty()
   # The regressing commit.

--- a/lib/osv/types.py
+++ b/lib/osv/types.py
@@ -130,13 +130,16 @@ class PackageTagInfo(ndb.Model):
   bugs_private = ndb.StringProperty(repeated=True)
 
 
-class CommitRange(ndb.Model):
-  """Commit range."""
-  # TODO(ochang): Add type and repo URL.
+class AffectedRange(ndb.Model):
+  """Affected range."""
+  # Type of range.
+  type = ndb.StringProperty()
+  # Repo URL.
+  repo_url = ndb.StringProperty()
   # The regressing commit.
-  introduced_in = ndb.StringProperty()
+  introduced = ndb.StringProperty()
   # The fix commit.
-  fixed_in = ndb.StringProperty()
+  fixed = ndb.StringProperty()
 
 
 class SourceOfTruth(enum.IntEnum):
@@ -162,15 +165,12 @@ class Bug(ndb.Model):
   # For OSS-Fuzz, this oss-fuzz:<ClusterFuzz testcase ID>.
   # For others this is <source>:<path/to/source>.
   source_id = ndb.StringProperty()
-  # Main repo url.
-  repo_url = ndb.StringProperty()
-  # The main fixed commit.
-  fixed = ndb.StringProperty()
-  # The main regressing commit.
-  regressed = ndb.StringProperty()
-  # Additional affected commit ranges derived from the main fixed and regressed
-  # commits.
-  additional_commit_ranges = ndb.StructuredProperty(CommitRange, repeated=True)
+  # The main fixed commit (from bisection).
+  fixed = ndb.StringProperty(default='')
+  # The main regressing commit (from bisection).
+  regressed = ndb.StringProperty(default='')
+  # All affected ranges.
+  affected_ranges = ndb.StructuredProperty(AffectedRange, repeated=True)
   # List of affected versions.
   affected = ndb.StringProperty(repeated=True)
   # List of normalized versions for fuzzy matching.
@@ -201,6 +201,8 @@ class Bug(ndb.Model):
   sort_key = ndb.StringProperty()
   # Source of truth for this Bug.
   source_of_truth = ndb.IntegerProperty(default=SourceOfTruth.INTERNAL)
+  # Whether the bug is fixed (indexed for querying).
+  is_fixed = ndb.BooleanProperty()
 
   def id(self):
     """Get the bug ID."""
@@ -208,6 +210,15 @@ class Bug(ndb.Model):
       return self.OSV_ID_PREFIX + self.key.id()
 
     return self.key.id()
+
+  @property
+  def repo_url(self):
+    """Repo URL."""
+    for affected_range in self.affected_ranges:
+      if affected_range.repo_url:
+        return affected_range.repo_url
+
+    return None
 
   @classmethod
   def get_by_id(cls, vuln_id, *args, **kwargs):
@@ -235,6 +246,9 @@ class Bug(ndb.Model):
     if not self.last_modified:
       self.last_modified = utcnow()
 
+    self.is_fixed = any(
+        affected_range.fixed for affected_range in self.affected_ranges)
+
   def update_from_vulnerability(self, vulnerability):
     """Set fields from vulnerability."""
     self.summary = vulnerability.summary
@@ -253,21 +267,15 @@ class Bug(ndb.Model):
     self.ecosystem = vulnerability.package.ecosystem
     self.affected = list(vulnerability.affects.versions)
 
-    found_first = False
+    self.affected_ranges = []
     for affected_range in vulnerability.affects.ranges:
-      if affected_range.type != vulnerability_pb2.AffectedRange.Type.GIT:
-        continue
-
-      if found_first:
-        self.additional_commit_ranges.append(
-            CommitRange(
-                introduced_in=affected_range.introduced,
-                fixed_in=affected_range.fixed))
-      else:
-        self.regressed = affected_range.introduced
-        self.fixed = affected_range.fixed
-        self.repo_url = affected_range.repo
-        found_first = True
+      self.affected_ranges.append(
+          AffectedRange(
+              type=vulnerability_pb2.AffectedRange.Type.Name(
+                  affected_range.type),
+              repo_url=affected_range.repo,
+              introduced=affected_range.introduced or '',
+              fixed=affected_range.fixed or ''))
 
   def to_vulnerability(self):
     """Convert to Vulnerability proto."""
@@ -275,17 +283,12 @@ class Bug(ndb.Model):
         name=self.project, ecosystem=self.ecosystem)
 
     affects = vulnerability_pb2.Affects(versions=self.affected)
-    affects.ranges.add(
-        type=vulnerability_pb2.AffectedRange.Type.GIT,
-        repo=self.repo_url,
-        introduced=self.regressed,
-        fixed=self.fixed)
-    for additional_range in self.additional_commit_ranges:
+    for affected_range in self.affected_ranges:
       affects.ranges.add(
-          type=vulnerability_pb2.AffectedRange.Type.GIT,
-          repo=self.repo_url,
-          introduced=additional_range.introduced_in,
-          fixed=additional_range.fixed_in)
+          type=vulnerability_pb2.AffectedRange.Type.Value(affected_range.type),
+          repo=affected_range.repo_url,
+          introduced=affected_range.introduced,
+          fixed=affected_range.fixed)
 
     if self.severity:
       severity = vulnerability_pb2.Severity.Value(self.severity)


### PR DESCRIPTION
Rather than only storing GIT ranges, we generalize the Datastore
properties to better reflect the actual vulnerability schema.

This is in preparation for storing ECOSYSTEM and SEMVER ranges.