### PR TITLE
Cleanup from previous migrations.

### DIFF
--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -91,9 +91,6 @@ class ImporterTest(unittest.TestCase):
             'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1064':
                 'REPORT'
         },
-        reference_urls=[
-            'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1064'
-        ],
         regressed='17ee4cf670c363de8d2ea4a4897d7a699837873f',
         search_indices=['file', '2017-134', '2017', '134'],
         severity='MEDIUM',

--- a/docker/worker/oss_fuzz.py
+++ b/docker/worker/oss_fuzz.py
@@ -209,7 +209,6 @@ def set_bug_attributes(bug, regress_result, fix_result):
   bug.summary = summary
   bug.details = details
   bug.severity = severity
-  bug.reference_urls = reference_urls
   bug.reference_url_types = {}
 
   for reference_url in reference_urls:

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -202,7 +202,6 @@ class ImpactTest(unittest.TestCase):
             'sort_key': '2020-0001337',
             'source_of_truth': osv.SourceOfTruth.INTERNAL,
             'public': False,
-            'reference_urls': ['https://url/'],
             'reference_url_types': {
                 'https://url/': 'WEB'
             },
@@ -284,7 +283,6 @@ class ImpactTest(unittest.TestCase):
             'ecosystem': 'ecosystem',
             'summary': 'Heap-buffer-overflow in Foo',
             'details': 'DETAILS',
-            'reference_urls': ['https://url/'],
             'reference_url_types': {
                 'https://url/': 'WEB'
             },
@@ -374,7 +372,6 @@ class ImpactTest(unittest.TestCase):
             'reference_url_types': {
                 'https://url/': 'WEB'
             },
-            'reference_urls': ['https://url/'],
             'severity': 'MEDIUM',
             'sort_key': '2020-0001337',
             'source_of_truth': osv.SourceOfTruth.INTERNAL,
@@ -465,7 +462,6 @@ class ImpactTest(unittest.TestCase):
             'reference_url_types': {
                 'https://url/': 'WEB'
             },
-            'reference_urls': ['https://url/'],
             'public': False,
             'status': osv.BugStatus.PROCESSED.value,
             'has_affected': True,
@@ -558,7 +554,6 @@ class ImpactTest(unittest.TestCase):
             'reference_url_types': {
                 'https://url/': 'WEB'
             },
-            'reference_urls': ['https://url/'],
             'public': False,
             'status': osv.BugStatus.PROCESSED.value,
             'has_affected': True,
@@ -623,7 +618,6 @@ class ImpactTest(unittest.TestCase):
             'reference_url_types': {
                 'https://url/': 'WEB'
             },
-            'reference_urls': ['https://url/'],
             'public': False,
             'status': osv.BugStatus.PROCESSED.value,
             'has_affected': True,
@@ -932,7 +926,6 @@ class UpdateTest(unittest.TestCase):
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
-            'reference_urls': ['https://ref.com/ref'],
             'regressed': '',
             'search_indices': ['blah.com/package', 'BLAH-123', 'BLAH', '123'],
             'severity': 'HIGH',
@@ -1014,7 +1007,6 @@ class UpdateTest(unittest.TestCase):
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
-            'reference_urls': ['https://ref.com/ref'],
             'regressed': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
             'search_indices': ['blah.com/package', 'BLAH-124', 'BLAH', '124'],
             'severity': 'HIGH',
@@ -1089,7 +1081,6 @@ class UpdateTest(unittest.TestCase):
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
-            'reference_urls': ['https://ref.com/ref'],
             'regressed': '',
             'search_indices': ['blah.com/package', 'BLAH-127', 'BLAH', '127'],
             'severity': 'HIGH',
@@ -1180,7 +1171,6 @@ class UpdateTest(unittest.TestCase):
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
-            'reference_urls': ['https://ref.com/ref'],
             'regressed': '',
             'search_indices': ['blah.com/package', 'BLAH-126', 'BLAH', '126'],
             'severity': 'HIGH',
@@ -1358,7 +1348,6 @@ class UpdateTest(unittest.TestCase):
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
-            'reference_urls': ['https://ref.com/ref'],
             'regressed': '',
             'search_indices': ['grpcio', 'PYSEC-123', 'PYSEC', '123'],
             'severity': 'HIGH',

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -125,7 +125,7 @@ def bug_to_response(bug, detailed=False):
     response['repo_url'] = bug.repo_url
     response['details'] = bug.details
     response['severity'] = bug.severity
-    response['references'] = bug.reference_urls
+    response['references'] = list(bug.reference_url_types.keys())
     response['regressed'] = _get_commits(
         bug,
         [affected_range.introduced for affected_range in bug.affected_ranges])

--- a/gcp/appengine/index.yaml
+++ b/gcp/appengine/index.yaml
@@ -77,12 +77,6 @@ indexes:
       - name: public
       - name: status
 
-  # TODO(ochang) remove after migration.
-  - kind: Bug
-    properties:
-      - name: fixed
-      - name: status
-
   - kind: Bug
     properties:
       - name: is_fixed


### PR DESCRIPTION
- Remove Bug.reference_urls. This was replaced with reference_url_types.
- Remove unneeded index.