### PR TITLE
Normalize Python package names for vulnfeeds.

### DIFF
--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -96,7 +96,8 @@ func main() {
 		log.Printf("Valid versions = %v\n", validVersions)
 
 		id := "PYSEC-" + cve.CVE.CVEDataMeta.ID
-		v, notes := vulns.FromCVE(id, cve, pkg, "PyPI", "ECOSYSTEM", validVersions)
+		normalizedPkg := pypi.NormalizePackageName(pkg)
+		v, notes := vulns.FromCVE(id, cve, normalizedPkg, "PyPI", "ECOSYSTEM", validVersions)
 		if len(v.Affects.Ranges) == 0 {
 			log.Printf("No affected versions detected.")
 		}
@@ -106,7 +107,7 @@ func main() {
 			log.Fatalf("Failed to marshal YAML: %v", err)
 		}
 
-		pkgDir := filepath.Join(*outDir, pkg)
+		pkgDir := filepath.Join(*outDir, normalizedPkg)
 		err = os.MkdirAll(pkgDir, 0755)
 		if err != nil {
 			log.Fatalf("Failed to create dir: %v", err)

--- a/vulnfeeds/pypi/pypi.go
+++ b/vulnfeeds/pypi/pypi.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -91,6 +92,13 @@ func loadVersions(path string) []pypiVersions {
 		log.Fatalf("Failed to parse %s: %v", err)
 	}
 	return versions
+}
+
+// NormalizePackageName normalizes a PyPI package name.
+func NormalizePackageName(name string) string {
+	// Per https://www.python.org/dev/peps/pep-0503/#normalized-names
+	re := regexp.MustCompile(`[-_.]+`)
+	return strings.ToLower(re.ReplaceAllString(name, "-"))
 }
 
 // extractVendorProduct takes a link and extracts the "vendor/product" from it


### PR DESCRIPTION
Per https://www.python.org/dev/peps/pep-0503/#normalized-names there are
multiple ways to refer to the same python package.