### PR TITLE
Implement an ID allocator for vulnerability repos.

### DIFF
--- a/vulnfeeds/README.md
+++ b/vulnfeeds/README.md
@@ -21,6 +21,8 @@ versions released in the package manager to ensure accuracy.
 
 ## Workflow
 
+### Scraping existing feeds
+
 The intended workflow is for a human to periodically run the tools here against
 the latest NVD CVE feeds.
 
@@ -40,20 +42,42 @@ This auto-generates matching `<ID>.yaml` files into `$VULNS_REPO/vulns`.
 
 However, human intervention will always be required in some cases, when versions
 cannot be reliably extracted automatically from CVE data. In these cases a
-corresponding `<ID>.notes` file will be generated alongside the `<ID>.yaml` file to
-indicate that a human should look at this.
+comment block will be appended to the `<ID>.yaml` to indicate that a human
+should look at this.
 
-An example `<ID>.notes` file will look like:
+An example notes block will look like:
 
 ```
-Warning: 2017.5.0 is not a valid introduced version
-Warning: 2018.2.0 is not a valid introduced version
-Warning: 3000.0 is not a valid introduced version
+# <Vulnfeeds Notes>
+# Warning: 2017.5.0 is not a valid introduced version
+# Warning: 2018.2.0 is not a valid introduced version
+# Warning: 3000.0 is not a valid introduced version
 ```
 
-These files should be removed once resolved and not commited into the repo.
-Subsequent runs of the tool will **not** overwrite existing `.yaml` files to
-preserve human edits.
+These files will have the placeholder ID format `<PREFIX>-0000-....` (where
+`<PREFIX>` is the database ID prefix, e.g. `PYSEC`).
+
+### Merging manual pull requests
+
+Entries can also be manually contributed via a pull request. These entries
+should use a placeholder ID of the format `<PREFIX>-0000-<anything>` to indicate
+that an ID needs to be assigned.
+
+### ID generation
+
+Once vulnerabilities are scraped (or pull requests are merged), we need to
+assign IDs. Do this by running:
+
+```
+export VULNS_REPO=/path/to/vulns/repo
+export PREFIX=PYSEC
+go run ./cmd/ids -dir $VULNS_REPO -prefix $PREFIX
+```
+
+This will replace previous placeholder IDs with IDs of the form
+`<PREFIX>-YEAR-NNN`.
+
+TODO: GitHub Action to do this.
 
 ### False positives
 

--- a/vulnfeeds/cmd/ids/main.go
+++ b/vulnfeeds/cmd/ids/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/osv/vulnfeeds/vulns"
+)
+
+const (
+	extension = ".yaml"
+)
+
+func main() {
+	prefix := flag.String("prefix", "", "Vulnerability prefix (e.g. \"PYSEC\".")
+	dir := flag.String("dir", "", "Path to vulnerabilites.")
+	flag.Parse()
+
+	if *prefix == "" || *dir == "" {
+		flag.Usage()
+		return
+	}
+
+	// TODO(ochang): Handle conflicts from parallel runs.
+	if err := assignIDs(*prefix, *dir); err != nil {
+		fmt.Printf("Failed to assign IDs: %v", err)
+	}
+}
+
+func extractYearAndNum(prefix, filename string) (int, int) {
+	// Extract year and num from "PREFIX-YEAR-NUM"
+	parts := strings.Split(strings.TrimSuffix(filename, extension), "-")
+	if len(parts) != 3 {
+		return 0, 0
+	}
+
+	if parts[0] != prefix {
+		return 0, 0
+	}
+
+	year, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0
+	}
+
+	num, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return 0, 0
+	}
+
+	return year, num
+}
+
+func isUnassigned(prefix, filename string) bool {
+	return strings.HasPrefix(filename, prefix+"-0000-")
+}
+
+func assignID(path, prefix string, yearCounters map[int]int, defaultYear int) error {
+	// Parse the existing vulnerability.
+	readf, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", path, err)
+	}
+	defer readf.Close()
+
+	vuln, err := vulns.FromYAML(readf)
+	if err != nil {
+		return fmt.Errorf("failed to parse YAML: %w", err)
+	}
+	readf.Close()
+
+	// If the vulnerability has a published date, use the year from that.
+	// Otherwise, just default to the current year.
+	year := defaultYear
+	if vuln.Published != "" {
+		published, err := time.Parse(time.RFC3339, vuln.Published)
+		if err != nil {
+			return fmt.Errorf("failed to parse published date: %w", err)
+		}
+		year = published.Year()
+	}
+
+	// Allocate a new ID and write the new file.
+	id := yearCounters[year]
+	yearCounters[year] += 1
+
+	vuln.ID = fmt.Sprintf("%s-%d-%d", prefix, year, id)
+	newPath := filepath.Join(filepath.Dir(path), vuln.ID+extension)
+
+	writef, err := os.Create(newPath)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", newPath, err)
+	}
+	defer writef.Close()
+
+	if err := vuln.ToYAML(writef); err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+	return os.Remove(path)
+}
+
+func assignIDs(prefix, dir string) error {
+	defaultYear := time.Now().Year()
+	var unassigned []string
+	yearCounters := map[int]int{}
+
+	// Look for unassigned vulnerabilities, as well as the maximum allocated IDs for every year.
+	err := filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to access %s: %w", path, err)
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		filename := filepath.Base(path)
+		if isUnassigned(prefix, filename) {
+			unassigned = append(unassigned, path)
+			return nil
+		}
+
+		year, num := extractYearAndNum(prefix, filename)
+		if year == 0 || num == 0 {
+			return nil
+		}
+
+		if num > yearCounters[year] {
+			yearCounters[year] = num
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to walk: %w", err)
+	}
+
+	fmt.Printf("Assigning IDs using detected maximums: %v\n", yearCounters)
+	for _, path := range unassigned {
+		if err := assignID(path, prefix, yearCounters, defaultYear); err != nil {
+			return fmt.Errorf("failed to assign ID: %w", err)
+		}
+	}
+	return nil
+}

--- a/vulnfeeds/cmd/ids/main.go
+++ b/vulnfeeds/cmd/ids/main.go
@@ -102,6 +102,8 @@ func assignID(path, prefix string, yearCounters map[int]int, defaultYear int) er
 	if err := vuln.ToYAML(writef); err != nil {
 		return fmt.Errorf("failed to serialize: %w", err)
 	}
+
+	fmt.Printf("Assigning %s to %s\n", path, newPath)
 	return os.Remove(path)
 }
 

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -16,7 +16,10 @@ package vulns
 
 import (
 	"fmt"
+	"io"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/google/osv/vulnfeeds/cves"
 )
@@ -115,4 +118,20 @@ func FromCVE(id string, cve cves.CVEItem, pkg, ecosystem, versionType string, va
 		})
 	}
 	return &v, notes
+}
+
+func FromYAML(r io.Reader) (*Vulnerability, error) {
+	decoder := yaml.NewDecoder(r)
+	var vuln Vulnerability
+	err := decoder.Decode(&vuln)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vuln, nil
+}
+
+func (v *Vulnerability) ToYAML(w io.Writer) error {
+	encoder := yaml.NewEncoder(w)
+	return encoder.Encode(v)
 }


### PR DESCRIPTION
Intended for use by community based vulnerability repos, where reports can can come from manual contributions from pull requests (where an ID may never have been assigned). 

This tool picks up any vulnerabilities with the ID format of `PREFIX-0000-` and assigns a real ID based on the previous maximum allocated ID in the repo. 

This can later be run as part of a GitHub action. 