### PR TITLE
Add settings to ignore source repo files and ignore git ranges.

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -240,11 +240,17 @@ class Importer:
 
     # Create tasks for changed files.
     for changed_entry in changed_entries:
+      if source_repo.ignore_file(changed_entry):
+        continue
+
       logging.info('Re-analysis triggered for %s', changed_entry)
       self._request_analysis_external(source_repo, repo, changed_entry)
 
     # Mark deleted entries as invalid.
     for deleted_entry in deleted_entries:
+      if source_repo.ignore_file(deleted_entry):
+        continue
+
       logging.info('Marking %s as invalid', deleted_entry)
       self._request_analysis_external(
           source_repo, repo, deleted_entry, deleted=True)

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -56,7 +56,8 @@ class ImporterTest(unittest.TestCase):
         id='oss-fuzz',
         name='oss-fuzz',
         repo_url='file://' + self.remote_source_repo_path,
-        repo_username='')
+        repo_username='',
+        ignore_patterns=['.*IGNORE.*'])
     self.source_repo.put()
 
   def tearDown(self):
@@ -275,6 +276,17 @@ class ImporterTest(unittest.TestCase):
     """Test no update marker."""
     self.mock_repo.add_file('2021-111.yaml', '')
     self.mock_repo.commit('User', 'user@email', 'message. OSV-NO-UPDATE')
+
+    imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
+                            'bucket')
+    imp.run()
+    mock_publish.assert_not_called()
+
+  @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
+  def test_ignore(self, mock_publish):
+    """Test ignoring."""
+    self.mock_repo.add_file('2021-111IGNORE.yaml', '')
+    self.mock_repo.commit('User', 'user@email', 'message.')
 
     imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
                             'bucket')

--- a/docker/worker/testdata/PYSEC-123.yaml
+++ b/docker/worker/testdata/PYSEC-123.yaml
@@ -6,12 +6,15 @@ summary: A vulnerability
 details: |
   Blah blah blah
   Blah
-severity: HIGH
 affects:
   ranges:
   - type: ECOSYSTEM
     introduced: 1.14.2
     fixed: 1.31.0
+  - type: GIT
+    repo: https://osv-test/repo/url
+    introduced: eefe8ec3f1f90d0e684890e810f3f21e8500a4cd
+    fixed: 8d8242f545e9cec3e6d0d2e3f5bde8be1c659735
 references:
 - type: WEB
   url: https://ref.com/ref

--- a/docker/worker/testdata/expected_pypi.diff
+++ b/docker/worker/testdata/expected_pypi.diff
@@ -1,11 +1,11 @@
 diff --git a/PYSEC-123.yaml b/PYSEC-123.yaml
-index 7f16594..6f04049 100644
+index 3714f05..8684499 100644
 --- a/PYSEC-123.yaml
 +++ b/PYSEC-123.yaml
-@@ -12,6 +12,59 @@ affects:
-   - type: ECOSYSTEM
-     introduced: 1.14.2
-     fixed: 1.31.0
+@@ -15,6 +15,59 @@ affects:
+     repo: https://osv-test/repo/url
+     introduced: eefe8ec3f1f90d0e684890e810f3f21e8500a4cd
+     fixed: 8d8242f545e9cec3e6d0d2e3f5bde8be1c659735
 +  versions:
 +  - 1.14.2
 +  - 1.15.0

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -387,7 +387,8 @@ class TaskRunner:
 
     try:
       for affected_range in vulnerability.affects.ranges:
-        if affected_range.type != vulnerability_pb2.AffectedRange.GIT:
+        if (affected_range.type != vulnerability_pb2.AffectedRange.GIT or
+            source_repo.ignore_git):
           continue
 
         # Convert empty values ('') to None.
@@ -398,7 +399,8 @@ class TaskRunner:
       for affected_range in vulnerability.affects.ranges:
         # Go through existing provided ranges to find additional ranges (via
         # cherrypicks and branches).
-        if affected_range.type != vulnerability_pb2.AffectedRange.GIT:
+        if (affected_range.type != vulnerability_pb2.AffectedRange.GIT or
+            source_repo.ignore_git):
           continue
 
         current_repo_url = affected_range.repo

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -833,11 +833,12 @@ class UpdateTest(unittest.TestCase):
         self._load_test_data(os.path.join(TEST_DATA_DIR, 'BLAH-127.yaml')))
     self.mock_repo.commit('User', 'user@email')
 
-    osv.SourceRepository(
+    self.source_repo = osv.SourceRepository(
         id='source',
         name='source',
         repo_url='file://' + self.remote_source_repo_path,
-        repo_username='').put()
+        repo_username='')
+    self.source_repo.put()
 
     osv.Bug(
         id='BLAH-123',
@@ -1277,6 +1278,9 @@ class UpdateTest(unittest.TestCase):
 
   def test_update_pypi(self):
     """Test a PyPI entry."""
+    self.source_repo.ignore_git = True
+    self.source_repo.put()
+
     self.mock_repo.add_file(
         'PYSEC-123.yaml',
         self._load_test_data(os.path.join(TEST_DATA_DIR, 'PYSEC-123.yaml')))
@@ -1287,8 +1291,8 @@ class UpdateTest(unittest.TestCase):
     message.attributes = {
         'source': 'source',
         'path': 'PYSEC-123.yaml',
-        'original_sha256': ('44a2ead7fa69e76be3d0033cce3fe05e'
-                            '63189ed6c2e72b88dffe73618b476e96'),
+        'original_sha256': ('c8313271c17c169afd795e7006d5b7f9'
+                            'd692359904c1c9bca39a007e3963f1c6'),
         'deleted': 'false',
     }
     task_runner._source_update(message)
@@ -1330,12 +1334,20 @@ class UpdateTest(unittest.TestCase):
                 '1-28-1', '1-29-0', '1-30-0', '1-30-0-rc1', '1-31-0-rc1',
                 '1-31-0-rc2'
             ],
-            'affected_ranges': [{
-                'fixed': '1.31.0',
-                'introduced': '1.14.2',
-                'repo_url': '',
-                'type': 'ECOSYSTEM'
-            }],
+            'affected_ranges': [
+                {
+                    'fixed': '1.31.0',
+                    'introduced': '1.14.2',
+                    'repo_url': '',
+                    'type': 'ECOSYSTEM'
+                },
+                {
+                    'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
+                    'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
+                    'repo_url': 'https://osv-test/repo/url',
+                    'type': 'GIT'
+                },
+            ],
             'details': 'Blah blah blah\nBlah\n',
             'ecosystem': 'PyPI',
             'fixed': '',
@@ -1350,7 +1362,7 @@ class UpdateTest(unittest.TestCase):
             },
             'regressed': '',
             'search_indices': ['grpcio', 'PYSEC-123', 'PYSEC', '123'],
-            'severity': 'HIGH',
+            'severity': None,
             'sort_key': 'PYSEC-0000123',
             'source_id': 'source:PYSEC-123.yaml',
             'source_of_truth': osv.SourceOfTruth.SOURCE_REPO,

--- a/lib/osv/repos.py
+++ b/lib/osv/repos.py
@@ -37,6 +37,8 @@ def clone_with_retries(git_url, checkout_dir, callbacks=None):
       time.sleep(RETRY_SLEEP_SECONDS)
       continue
 
+  return None
+
 
 def _use_existing_checkout(git_url, checkout_dir, git_callbacks):
   """Update and use existing checkout."""


### PR DESCRIPTION
This allows us to ignore certain files in source repositories (e.g.
unallocated IDs) when importing vulnerabilities.

Vulnerabilities with well defined ECOSYSTEM/SEMVER ranges should also
not have git ranges expanded, as they do not necessarily match the
package manager versions and just add confusion. We may revisit
this in the future.