### PR TITLE
Various fixes in preparation for loading additional sources.

### DIFF
--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -455,6 +455,7 @@ class TaskRunner:
           source_of_truth=osv.SourceOfTruth.SOURCE_REPO)
 
     bug.update_from_vulnerability(vulnerability)
+    bug.public = True
     bug.put()
 
     osv.update_affected_commits(bug.key.id(), commits, bug.project,

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -923,7 +923,7 @@ class UpdateTest(unittest.TestCase):
             'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
-            'public': None,
+            'public': True,
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
@@ -1004,7 +1004,7 @@ class UpdateTest(unittest.TestCase):
             'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
-            'public': None,
+            'public': True,
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
@@ -1078,7 +1078,7 @@ class UpdateTest(unittest.TestCase):
             'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
-            'public': None,
+            'public': True,
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
@@ -1168,7 +1168,7 @@ class UpdateTest(unittest.TestCase):
             'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'blah.com/package',
-            'public': None,
+            'public': True,
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },
@@ -1356,7 +1356,7 @@ class UpdateTest(unittest.TestCase):
             'is_fixed': True,
             'last_modified': datetime.datetime(2021, 1, 1, 0, 0),
             'project': 'grpcio',
-            'public': None,
+            'public': True,
             'reference_url_types': {
                 'https://ref.com/ref': 'WEB'
             },

--- a/gcp/appengine/frontend/src/components/List.vue
+++ b/gcp/appengine/frontend/src/components/List.vue
@@ -108,8 +108,7 @@ export default {
     async makeRequest() {
       const curId = ++this.requestId;
       const response = await fetch(
-          `/backend/query?page=${this.currentPage}&search=${this.queryParam}&affected_only=${this.affectedOnly}`,
-          { credentials: 'include' });
+          `/backend/query?page=${this.currentPage}&search=${this.queryParam}&affected_only=${this.affectedOnly}`);
 
       const results = await response.json();
       if (curId != this.requestId) {

--- a/gcp/appengine/frontend/src/components/List.vue
+++ b/gcp/appengine/frontend/src/components/List.vue
@@ -66,7 +66,6 @@
         <div v-else>
           No impacted versions.
         </div>
-        </span>
       </template>
     </b-table>
   </div>

--- a/gcp/appengine/frontend/src/components/List.vue
+++ b/gcp/appengine/frontend/src/components/List.vue
@@ -54,16 +54,19 @@
           <router-link :to="getVulnerabilityLink(summary.item.id)">(Details)</router-link>
         </p>
       </template>
-      <template v-slot:cell(affected)="data">
-        <div v-for="affected in data.value.slice(0, 8)" :key="affected">
-          {{affected.tag}}
-        </div>
-        <div v-if="data.value.length > 8" v-b-popover.hover.right="formatLongAffected(data.value.slice(8))">
-          ...
-        </div>
-        <div v-if="data.value.length == 0">
+      <template v-slot:cell(affects)="data">
+        <span v-if="data.value.versions && data.value.versions.length > 0">
+          <div v-for="version in data.value.versions.slice(0, 8)" :key="version">
+            {{version}}
+          </div>
+          <div v-if="data.value.versions.length > 8" v-b-popover.hover.right="formatLongAffected(data.value.versions.slice(8))">
+            ...
+          </div>
+        </span>
+        <div v-else>
           No impacted versions.
         </div>
+        </span>
       </template>
     </b-table>
   </div>
@@ -96,7 +99,7 @@ export default {
             label: 'Summary',
         },
         {
-            key: 'affected',
+            key: 'affects',
         },
       ]
     };

--- a/gcp/appengine/frontend/src/components/Package.vue
+++ b/gcp/appengine/frontend/src/components/Package.vue
@@ -57,8 +57,7 @@ export default {
     async makeRequest() {
       const curId = ++this.requestId;
       const response = await fetch(
-          `/backend/package?package=${this.$route.params.package}`,
-          { credentials: 'include' });
+          `/backend/package?package=${this.$route.params.package}`);
       if (response.status != 200) {
         this.$router.replace({name: 'notfound'});
       }

--- a/gcp/appengine/frontend/src/components/Vulnerability.vue
+++ b/gcp/appengine/frontend/src/components/Vulnerability.vue
@@ -176,7 +176,7 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
 #vuln {
-    max-width: 1000px;
+  max-width: 1000px;
 }
 
 .version {
@@ -184,6 +184,6 @@ export default {
 }
 
 pre {
-    white-space: pre-wrap;
+  white-space: pre-wrap;
 }
 </style>

--- a/gcp/appengine/frontend/src/components/Vulnerability.vue
+++ b/gcp/appengine/frontend/src/components/Vulnerability.vue
@@ -119,8 +119,7 @@ export default {
     async makeRequest() {
       const curId = ++this.requestId;
       const response = await fetch(
-          `/backend/vulnerability?id=${this.$route.params.vulnId}`,
-          { credentials: 'include' });
+          `/backend/vulnerability?id=${this.$route.params.vulnId}`);
       if (response.status != 200) {
         this.$router.replace({name: 'notfound'});
       }

--- a/gcp/appengine/frontend/src/components/Vulnerability.vue
+++ b/gcp/appengine/frontend/src/components/Vulnerability.vue
@@ -20,7 +20,7 @@
     <b-alert v-if="invalid" show variant="warning">
       This entry is invalid due to reproduction flake.
     </b-alert>
-    <b-table-simple>
+    <b-table-simple id="vuln">
       <b-tr>
         <b-td>Package</b-td>
         <b-td>
@@ -30,7 +30,9 @@
       <b-tr>
         <b-td>Repo URL</b-td>
         <b-td>
-        <a :href="repo_url">{{ repo_url }}</a>
+        <a v-for="repo_url in repo_urls" :key="repo_url" :href="repo_url">
+          {{ repo_url }}
+        </a>
         </b-td>
       </b-tr>
       <b-tr>
@@ -42,42 +44,42 @@
         <b-td><pre>{{ details }}</pre></b-td>
       </b-tr>
       <b-tr>
-        <b-td>Severity</b-td>
-        <b-td>{{ severity }}</b-td>
-      </b-tr>
-      <b-tr>
-        <b-td>Introduced in</b-td>
+        <b-td>Affected ranges</b-td>
         <b-td>
-          <div v-for="commit in introduced_in" :key="commit.id">
-            <a v-if="commit.link" :href="commit.link">
-              <span v-html="formatCommit(commit)"></span>
-            </a>
-            <span v-else v-html="formatCommit(commit)"></span>
-          </div>
+          <b-table-simple borderless smalls>
+            <b-tr>
+              <b-th>Type</b-th>
+              <b-th>Introduced</b-th>
+              <b-th>Fixed</b-th>
+            </b-tr>
+            <b-tr v-for="affected in affects.ranges" :key="affected.id">
+            <b-td>{{affected.type}}</b-td>
+            <b-td>
+              <a v-if="affected.introduced_link" :href="affected.introduced_link">
+                <span v-html="formatRangeVersion(affected.introduced)"></span>
+              </a>
+              <span v-else v-html="formatRangeVersion(affected.introduced)"></span>
+            </b-td>
+            <b-td>
+              <a v-if="affected.fixed_link" :href="affected.fixed_link">
+                <span v-html="formatRangeVersion(affected.fixed)"></span>
+              </a>
+              <span v-else v-html="formatRangeVersion(affected.fixed)"></span>
+            </b-td>
+            </b-tr>
+          </b-table-simple>
         </b-td>
-      </b-tr>
-      <b-tr>
-        <b-td>Fixed in</b-td>
-        <b-td v-if="fixed_in">
-          <div v-for="commit in fixed_in" :key="commit.id">
-            <a v-if="commit.link" :href="commit.link">
-              <span v-html="formatCommit(commit)"></span>
-            </a>
-            <span v-else v-html="formatCommit(commit)"></span>
-          </div>
-        </b-td>
-        <b-td v-else><strong>Not fixed</strong></b-td>
       </b-tr>
       <b-tr>
         <b-td>Affected versions</b-td>
         <b-td>
-          <span v-for="version in affected" :key="version">
-            {{version.tag}}
-          </span>
           <span v-if="invalid">
             INVALID
           </span>
-          <span v-else-if="affected.length == 0">
+          <span class="version" v-else-if="affects.versions && affects.versions.length > 0" v-for="version in affects.versions" :key="version">
+            <code>{{version}}</code>
+          </span>
+          <span v-else>
             No impacted versions.
           </span>
         </b-td>
@@ -85,8 +87,8 @@
       <b-tr>
         <b-td>References</b-td>
         <b-td>
-          <div v-for="link in references" :key="link">
-            <a :href="link">{{ link }}</a>
+          <div v-for="link in references" :key="link.url">
+            <a :href="link.url">{{ link.url }}</a>
           </div>
         </b-td>
       </b-tr>
@@ -103,13 +105,10 @@ export default {
   data() {
     return {
       package_value: {},
-      repo_url: '',
+      repo_urls: [],
       summary: '',
       details: '',
-      severity: '',
-      introduced_in: {},
-      fixed_in: null,
-      affected: [],
+      affects: {},
       references: [],
       invalid: false,
       requestId: 0,
@@ -133,33 +132,33 @@ export default {
       }
 
       this.package_value = results.package;
-      this.repo_url = results.repo_url;
       this.summary = results.summary;
       this.details = results.details;
-      this.severity = results.severity;
-      this.introduced_in = results.regressed;
-      if (results.fixed) {
-        this.fixed_in = results.fixed;
-      } else {
-        this.fixed_in = null
-      }
-      this.affected = results.affected;
+      this.affects = results.affects;
       this.references = results.references;
       this.invalid = results.invalid;
+      this.repo_urls = new Set();
+      for (let affected of this.affects.ranges) {
+        if (affected.repo) {
+          this.repo_urls.add(affected.repo);
+        }
+      }
 
       document.title = `${results.id}`;
     },
 
-    formatCommit(commit) {
-      if (!commit)
-        return '';
-
-      if (commit.type == 'exact') {
-        return commit.commit;
+    formatRangeVersion(version) {
+      if (!version) {
+        return "None";
       }
 
-      return commit.from + '<br>..<br>' + commit.to;
-    },
+      if (version.includes(":")) {
+        let parts = version.split(":");
+        return parts[0] + "..<br>" + parts[1];
+      }
+
+      return version;
+    }
   },
 
   watch: {
@@ -175,8 +174,16 @@ export default {
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
-<style scoped>
-.search {
-  max-width: 400px;
+<style>
+#vuln {
+    max-width: 1000px;
+}
+
+.version {
+  margin-right: 1em;
+}
+
+pre {
+    white-space: pre-wrap;
 }
 </style>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -32,8 +32,6 @@ blueprint = Blueprint('frontend_handlers', __name__)
 _BACKEND_ROUTE = '/backend'
 _PAGE_SIZE = 16
 _PAGE_LOOKAHEAD = 4
-_IAP_ACCOUNT_NAMESPACE = 'accounts.google.com:'
-_OSS_FUZZ_TRACKER_URL = 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id='
 _REQUESTS_PER_MIN = 30
 
 
@@ -60,39 +58,7 @@ def index():
   return render_template('index.html')
 
 
-def _to_commit(bug, commit_hash):
-  """Convert a commit hash to a Commit structure."""
-  commit = {
-      'repoType': 'git',  # TODO(ochang): Remove hardcode.
-      'repoUrl': bug.repo_url,
-  }
-
-  if ':' in commit_hash:
-    commit['type'] = 'range'
-    commit['from'], commit['to'] = commit_hash.split(':')
-    return commit
-
-  commit['type'] = 'exact'
-  commit['commit'] = commit_hash
-  return commit
-
-
-def _get_commits(bug, ranges, attr):
-  """Get commits."""
-  versions = []
-  for i, version in enumerate(set(versions)):
-    if version is None:
-      continue
-
-    commit = _to_commit(bug, commit_hash)
-    commit['link'] = _commit_to_link(commit)
-    commit['id'] = i
-    commits.append(commit)
-
-  return commits
-
-
-def bug_to_response(bug, detailed=False):
+def bug_to_response(bug):
   """Convert a Bug entity to a response object."""
   response = osv.vulnerability_to_dict(bug.to_vulnerability())
   response.update({
@@ -116,7 +82,8 @@ def add_links(bug):
       continue
 
     if affected.get('introduced'):
-      affected['introduced_link'] = _commit_to_link(repo_url, affected['introduced'])
+      affected['introduced_link'] = _commit_to_link(repo_url,
+                                                    affected['introduced'])
 
     if affected.get('fixed'):
       affected['fixed_link'] = _commit_to_link(repo_url, affected['fixed'])
@@ -242,4 +209,4 @@ def vulnerability_handler():
     abort(403)
     return None
 
-  return jsonify(bug_to_response(bug, detailed=True))
+  return jsonify(bug_to_response(bug))

--- a/lib/osv/sources.py
+++ b/lib/osv/sources.py
@@ -95,7 +95,6 @@ class _YamlDumper(yaml.SafeDumper):
 _YamlDumper.add_representer(str, _yaml_str_representer)
 
 
-
 def vulnerability_to_dict(vulnerability):
   """Convert Vulnerability to a dict."""
   return json_format.MessageToDict(vulnerability)

--- a/lib/osv/sources.py
+++ b/lib/osv/sources.py
@@ -95,10 +95,16 @@ class _YamlDumper(yaml.SafeDumper):
 _YamlDumper.add_representer(str, _yaml_str_representer)
 
 
+
+def vulnerability_to_dict(vulnerability):
+  """Convert Vulnerability to a dict."""
+  return json_format.MessageToDict(vulnerability)
+
+
 def vulnerability_to_yaml(vulnerability, output_path):
   """Convert Vulnerability to YAML."""
   with open(output_path, 'w') as handle:
-    data = json_format.MessageToDict(vulnerability)
+    data = vulnerability_to_dict(vulnerability)
     yaml.dump(data, handle, sort_keys=False, Dumper=_YamlDumper)
 
 


### PR DESCRIPTION
- Fix UI to show the correct IDs for non-OSV IDs.
- Fix UI to show non-git ranges.
- Use the Vulnerability JSON for rendering on the frontend, rather than
  building a custom JSON.
- Set Bug entities created from SourceRepositories to public by default.