### PR TITLE
Add a semver_index library.

### DIFF
--- a/lib/osv/semver_index.py
+++ b/lib/osv/semver_index.py
@@ -1,0 +1,81 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SemVer indexer."""
+
+import semver
+
+_PAD_WIDTH = 8
+_FAKE_PRE_WIDTH = 16
+
+
+def normalize(version):
+  """Normalize semver version for indexing (to allow for lexical
+  sorting/filtering)."""
+  version = semver.VersionInfo.parse(version)
+
+  # Precedence rules: https://semver.org/#spec-item-11
+
+  # 1. Precedence MUST be calculated by separating the version into major,
+  # minor, patch and pre-release identifiers in that order (Build metadata does
+  # not figure into precedence).
+  #
+  # Normalization: Per spec build metadata is ignored.
+
+  # 2. Precedence is determined by the first difference when comparing each of
+  # these identifiers from left to right as follows: Major, minor, and patch
+  # versions are always compared numerically.
+  #
+  # Normalization: Pad the components with '0' to allow for lexical ordering of
+  # numbers.
+  core_parts = '{}.{}.{}'.format(
+      str(version.major).rjust(_PAD_WIDTH, '0'),
+      str(version.minor).rjust(_PAD_WIDTH, '0'),
+      str(version.patch).rjust(_PAD_WIDTH, '0'))
+
+  # 3. When major, minor, and patch are equal, a pre-release version has lower
+  # precedence than a normal version:
+  #
+  # Normalization: Attach a very long fake prerelease version that is most
+  # likely to come after any real prelease version.
+  if not version.prerelease:
+    pre = 'z' * _FAKE_PRE_WIDTH
+    return f'{core_parts}-{pre}'
+
+  # 4. Precedence for two pre-release versions with the same major, minor, and
+  # patch version MUST be determined by comparing each dot separated identifier
+  # from left to right until a difference is found as follows:
+  #
+  # Normalization: Pad the components.
+  pre_components = []
+  for component in version.prerelease.split('.'):
+    # 3. Numeric identifiers always have lower precedence than non-numeric
+    # identifiers.
+    #
+    # Normalization: Pad numeric components with '0', and prefix alphanumeric
+    # with a single '1' (to ensure they always come after).
+    if component.isdigit():
+      # 1. Identifiers consisting of only digits are compared numerically.
+      pre_components.append(component.rjust(_PAD_WIDTH, '0'))
+    else:
+      # 2. Identifiers with letters or hyphens are compared lexically in ASCII
+      # sort order.
+      pre_components.append('1' + component)
+
+  # 4. A larger set of pre-release fields has a higher precedence than a smaller
+  # set, if all of the preceding identifiers are equal.
+  #
+  # Consistent with lexical sorting after normalization.
+
+  pre = '.'.join(pre_components)
+  return f'{core_parts}-{pre}'

--- a/lib/osv/semver_index_test.py
+++ b/lib/osv/semver_index_test.py
@@ -49,6 +49,7 @@ class SemverIndexTests(unittest.TestCase):
   def test_sort(self):
     """Test sorting."""
     versions = [
+        '1.0.2', '1.0.11', '1.9.0', '1.11.0',
         '1.0.1-20191109021931-daa7c04131f5',
         '1.0.1-pre.0.20191109021931-daa7c04131f5',
         '1.0.1-0.20191109021931-daa7c04131f5', '1.0.1-beta.2', '1.0.1-beta.11',
@@ -57,10 +58,23 @@ class SemverIndexTests(unittest.TestCase):
     ]
 
     self.assertListEqual([
-        '1.0.1-0.20191109021931-daa7c04131f5', '1.0.1-9', '1.0.1-0a',
-        '1.0.1-20191109021931-daa7c04131f5', '1.0.1-alpha', '1.0.1-alpha.1',
-        '1.0.1-alpha.beta', '1.0.1-beta', '1.0.1-beta.2', '1.0.1-beta.11',
-        '1.0.1-pre.0.20191109021931-daa7c04131f5', '1.0.1-rc.1', '1.0.1'
+        '1.0.1-0.20191109021931-daa7c04131f5',
+        '1.0.1-9',
+        '1.0.1-0a',
+        '1.0.1-20191109021931-daa7c04131f5',
+        '1.0.1-alpha',
+        '1.0.1-alpha.1',
+        '1.0.1-alpha.beta',
+        '1.0.1-beta',
+        '1.0.1-beta.2',
+        '1.0.1-beta.11',
+        '1.0.1-pre.0.20191109021931-daa7c04131f5',
+        '1.0.1-rc.1',
+        '1.0.1',
+        '1.0.2',
+        '1.0.11',
+        '1.9.0',
+        '1.11.0',
     ], sorted(versions, key=semver_index.normalize))
 
     # Sanity check that the python semver library agrees.

--- a/lib/osv/semver_index_test.py
+++ b/lib/osv/semver_index_test.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SemVer index tests."""
+
+import unittest
+
+import semver
+
+import semver_index
+
+
+class SemverIndexTests(unittest.TestCase):
+  """SemVer index tests."""
+
+  def test_normalize(self):
+    """Test version normalization."""
+    versions = [
+        '1.0.0-beta.2+BLAH', '1.0.0-beta.2', '1.0.0-beta.11', '1.0.0-rc.1',
+        '1.0.0', '1.0.0-alpha', '1.0.0-alpha.1', '1.0.0-alpha.beta',
+        '1.0.0-beta', '1.0.0-9', '1.0.0-0a',
+        '24.4.3001-20191109021931-daa7c04131f5'
+    ]
+
+    self.assertListEqual([
+        '00000001.00000000.00000000-1beta.00000002',
+        '00000001.00000000.00000000-1beta.00000002',
+        '00000001.00000000.00000000-1beta.00000011',
+        '00000001.00000000.00000000-1rc.00000001',
+        '00000001.00000000.00000000-zzzzzzzzzzzzzzzz',
+        '00000001.00000000.00000000-1alpha',
+        '00000001.00000000.00000000-1alpha.00000001',
+        '00000001.00000000.00000000-1alpha.1beta',
+        '00000001.00000000.00000000-1beta',
+        '00000001.00000000.00000000-00000009', '00000001.00000000.00000000-10a',
+        '00000024.00000004.00003001-120191109021931-daa7c04131f5'
+    ], [semver_index.normalize(version) for version in versions])
+
+  def test_sort(self):
+    """Test sorting."""
+    versions = [
+        '1.0.1-20191109021931-daa7c04131f5',
+        '1.0.1-pre.0.20191109021931-daa7c04131f5',
+        '1.0.1-0.20191109021931-daa7c04131f5', '1.0.1-beta.2', '1.0.1-beta.11',
+        '1.0.1-rc.1', '1.0.1', '1.0.1-alpha', '1.0.1-alpha.1',
+        '1.0.1-alpha.beta', '1.0.1-beta', '1.0.1-9', '1.0.1-0a'
+    ]
+
+    self.assertListEqual([
+        '1.0.1-0.20191109021931-daa7c04131f5', '1.0.1-9', '1.0.1-0a',
+        '1.0.1-20191109021931-daa7c04131f5', '1.0.1-alpha', '1.0.1-alpha.1',
+        '1.0.1-alpha.beta', '1.0.1-beta', '1.0.1-beta.2', '1.0.1-beta.11',
+        '1.0.1-pre.0.20191109021931-daa7c04131f5', '1.0.1-rc.1', '1.0.1'
+    ], sorted(versions, key=semver_index.normalize))
+
+    # Sanity check that the python semver library agrees.
+    self.assertListEqual(
+        sorted(versions, key=semver.VersionInfo.parse),
+        sorted(versions, key=semver_index.normalize))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This will be used to normalize semver into something that can be
lexically compared and indexed.

This index will be used to efficiently serve OSV queries for ecosystems
that enforce SEMVER (e.g. Go, Rust), without having to pre-compute all
released versions.

For ecosystems like Go, this is also necessary as versions are often
specified as a "pseudo-version" which isn't a real release e.g.
"v0.0.0-20180523231146-b3f5c0f6e5f1" and having Go-specific logic to
pre-compute every single one to serve queries is not ideal.