### PR TITLE
Remove some indexes.

### DIFF
--- a/gcp/appengine/frontend/src/components/Home.vue
+++ b/gcp/appengine/frontend/src/components/Home.vue
@@ -32,7 +32,7 @@
         <a href="https://github.com/google/oss-fuzz">OSS-Fuzz</a> (mostly C/C++),
         <a href="https://github.com/pypa/advisory-db">Python</a>, and
         <a href="https://github.com/golang/vulndb">Go</a>.
-        More <a href="https://github.com/google/osv/issues/44">to come<a/>.
+        More <a href="https://github.com/google/osv/issues/44">to come</a>.
       </p>
       <h4>Triaging vulnerabilities</h4>
       <p>

--- a/gcp/appengine/frontend/src/components/Package.vue
+++ b/gcp/appengine/frontend/src/components/Package.vue
@@ -17,8 +17,7 @@
 <template>
   <div>
     <h1>{{ this.$route.params.package }}</h1>
-    <p>Latest tag: {{ latestTag }} </p>
-    <h2>Tags with vulnerabilities</h2>
+    <h2>Versions with vulnerabilities</h2>
 
     <b-table
       id="my-table"
@@ -39,7 +38,6 @@ export default {
   name: 'Package',
   data() {
     return {
-      latestTag: '',
       bugs: [],
       requestId: 0,
       fields: [
@@ -68,7 +66,6 @@ export default {
         return;
       }
 
-      this.latestTag = results.latestTag;
       this.bugs = results.bugs;
 
       document.title = `OSV - ${this.$route.params.package}`;

--- a/gcp/appengine/handlers.py
+++ b/gcp/appengine/handlers.py
@@ -194,7 +194,7 @@ def generate_package_info_tasks():
   publisher = pubsub_v1.PublisherClient()
   query = osv.Bug.query(distinct_on=(osv.Bug.project, osv.Bug.ecosystem))
   for result in query:
-    if not result.project or not result.repo_url:
+    if not result.project:
       continue
 
     if result.ecosystem is None:
@@ -206,8 +206,7 @@ def generate_package_info_tasks():
         data=b'',
         type='package_info',
         package_name=result.project,
-        ecosystem=result.ecosystem,
-        repo_url=result.repo_url)
+        ecosystem=result.ecosystem)
 
   return 'done'
 

--- a/gcp/appengine/index.yaml
+++ b/gcp/appengine/index.yaml
@@ -27,19 +27,6 @@ indexes:
 
   - kind: Bug
     properties:
-      - name: project
-      - name: ecosystem
-      - name: affected
-
-  - kind: Bug
-    properties:
-      - name: project
-      - name: ecosystem
-      - name: affected
-      - name: public
-
-  - kind: Bug
-    properties:
       - name: status
       - name: project
       - name: ecosystem
@@ -142,9 +129,3 @@ indexes:
     - name: package
     - name: ecosystem
     - name: bugs
-
-  - kind: PackageTagInfo
-    properties:
-    - name: package
-    - name: ecosystem
-    - name: bugs_private

--- a/lib/osv/models.py
+++ b/lib/osv/models.py
@@ -121,12 +121,6 @@ class FixResult(ndb.Model):
   timestamp = ndb.DateTimeProperty()
 
 
-class PackageInfo(ndb.Model):
-  """Package info."""
-  # The latest tag for the package.
-  latest_tag = ndb.StringProperty()
-
-
 class PackageTagInfo(ndb.Model):
   """Project tag information."""
   # The name of the package.
@@ -137,8 +131,6 @@ class PackageTagInfo(ndb.Model):
   tag = ndb.StringProperty()
   # List of public bugs.
   bugs = ndb.StringProperty(repeated=True)
-  # List of private bugs.
-  bugs_private = ndb.StringProperty(repeated=True)
 
 
 class AffectedRange(ndb.Model):
@@ -185,8 +177,8 @@ class Bug(ndb.Model):
   # All affected ranges.
   affected_ranges = ndb.StructuredProperty(AffectedRange, repeated=True)
   # List of affected versions.
-  affected = ndb.StringProperty(repeated=True)
-  # List of normalized versions for fuzzy matching.
+  affected = ndb.TextProperty(repeated=True)
+  # List of normalized versions indexed for fuzzy matching.
   affected_fuzzy = ndb.StringProperty(repeated=True)
   # OSS-Fuzz issue ID.
   issue_id = ndb.StringProperty()


### PR DESCRIPTION
"affected" can be quite large, so we should only index it once rather
than 4x previously.

Also fix package_info task to not rely on these indexes, and generalize
it to not require a Repo URL.