### PR TITLE
Add an exporter.

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -13,7 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-docker build -t gcr.io/oss-vdb/importer:$1 . && \
-docker build -t gcr.io/oss-vdb/importer:latest . && \
-docker push gcr.io/oss-vdb/importer:$1 && \
-docker push gcr.io/oss-vdb/importer:latest
+pushd worker
+./build.sh $1
+popd
+
+pushd importer
+./build.sh $1
+popd
+
+pushd exporter
+./build.sh $1
+popd

--- a/docker/exporter/Dockerfile
+++ b/docker/exporter/Dockerfile
@@ -1,4 +1,3 @@
-#!/bin/bash -x
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-docker build -t gcr.io/oss-vdb/importer:$1 . && \
-docker build -t gcr.io/oss-vdb/importer:latest . && \
-docker push gcr.io/oss-vdb/importer:$1 && \
-docker push gcr.io/oss-vdb/importer:latest
+FROM gcr.io/oss-vdb/worker
+
+COPY exporter.py /usr/local/bin
+RUN chmod 755 /usr/local/bin/exporter.py
+ENTRYPOINT ["exporter.py"]

--- a/docker/exporter/build.sh
+++ b/docker/exporter/build.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-docker build -t gcr.io/oss-vdb/importer:$1 . && \
-docker build -t gcr.io/oss-vdb/importer:latest . && \
-docker push gcr.io/oss-vdb/importer:$1 && \
-docker push gcr.io/oss-vdb/importer:latest
+docker build -t gcr.io/oss-vdb/exporter:$1 . && \
+docker build -t gcr.io/oss-vdb/exporter:latest . && \
+docker push gcr.io/oss-vdb/exporter:$1 && \
+docker push gcr.io/oss-vdb/exporter:latest

--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSV Exporter."""
+import argparse
+import concurrent.futures
+import logging
+import os
+import tempfile
+import zipfile
+
+from google.cloud import ndb
+from google.cloud import storage
+
+import osv
+
+DEFAULT_WORK_DIR = '/work'
+
+_EXPORT_BUCKET = 'osv-vulnerabilities'
+_EXPORT_WORKERS = 32
+
+
+class Exporter:
+  """Exporter."""
+
+  def __init__(self, work_dir, export_bucket):
+    self._work_dir = work_dir
+    self._export_bucket = export_bucket
+
+  def run(self):
+    """Run exporter."""
+    query = osv.Bug.query(projection=[osv.Bug.ecosystem], distinct=True)
+    ecosystems = [bug.ecosystem for bug in query if bug.ecosystem]
+
+    for ecosystem in ecosystems:
+      with tempfile.TemporaryDirectory() as tmp_dir:
+        self._export_ecosystem_to_bucket(ecosystem, tmp_dir)
+
+  def _export_ecosystem_to_bucket(self, ecosystem, tmp_dir):
+    """Export ecosystem vulns to bucket."""
+    logging.info('Exporting vulnerabilities for ecosystem %s', ecosystem)
+    storage_client = storage.Client()
+    bucket = storage_client.get_bucket(self._export_bucket)
+
+    zip_path = os.path.join(tmp_dir, 'all.zip')
+    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+      for bug in osv.Bug.query(osv.Bug.ecosystem == ecosystem):
+        if not bug.public or not bug.status == osv.BugStatus.PROCESSED:
+          continue
+
+        file_path = os.path.join(tmp_dir, bug.id() + '.json')
+        osv.write_vulnerability(
+            bug.to_vulnerability(include_source=True), file_path)
+        zip_file.write(file_path, os.path.basename(file_path))
+
+    def upload_single(source_path, target_path):
+      """Upload a single vulnerability."""
+      logging.info('Uploading %s', target_path)
+      try:
+        blob = bucket.blob(target_path)
+        blob.upload_from_filename(source_path)
+      except Exception as e:
+        logging.error('Failed to export: %s', e)
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=_EXPORT_WORKERS) as executor:
+      for filename in os.listdir(tmp_dir):
+        executor.submit(upload_single, os.path.join(tmp_dir, filename),
+                        f'{ecosystem}/{filename}')
+
+
+def main():
+  logging.basicConfig(level=logging.INFO)
+  parser = argparse.ArgumentParser(description='Exporter')
+  parser.add_argument(
+      '--work_dir', help='Working directory', default=DEFAULT_WORK_DIR)
+  args = parser.parse_args()
+
+  tmp_dir = os.path.join(args.work_dir, 'tmp')
+  os.makedirs(tmp_dir, exist_ok=True)
+  os.environ['TMPDIR'] = tmp_dir
+
+  exporter = Exporter(args.work_dir, _EXPORT_BUCKET)
+  exporter.run()
+
+
+if __name__ == '__main__':
+  _ndb_client = ndb.Client()
+  with _ndb_client.context():
+    main()


### PR DESCRIPTION
This regularly exports all OSV known vulnerabilities to a bucket with a
consistent structure:

- `gs://osv-vulnerabilities/<ecosystem>/<ID>.json`
- `gs://osv-vulnerabilities/<ecosystem>/all.zip`