### PR TITLE
Many commit impact calculation fixes.

### DIFF
--- a/docker/worker/oss_fuzz.py
+++ b/docker/worker/oss_fuzz.py
@@ -286,7 +286,7 @@ def process_impact_task(source_id, message):
     # Actually compute the affected commits/tags.
     repo_analyzer = osv.RepoAnalyzer()
     result = repo_analyzer.get_affected(repo, regress_result.commit, fix_commit)
-    affected_tags = sorted(list(result.tags_with_bug - result.tags_with_fix))
+    affected_tags = sorted(list(result.tags))
     logging.info('Found affected %s', ', '.join(affected_tags))
 
   # If the range resolved to a single commit, simplify it.
@@ -307,7 +307,7 @@ def process_impact_task(source_id, message):
   osv.update_affected_commits(allocated_bug_id, result.commits, project,
                               ecosystem, public)
 
-  affected_tags = sorted(list(result.tags_with_bug - result.tags_with_fix))
+  affected_tags = sorted(list(result.tags))
   existing_bug.fixed = fix_commit
   existing_bug.regressed = regress_commit
   existing_bug.affected = affected_tags

--- a/docker/worker/testdata/expected_127.diff
+++ b/docker/worker/testdata/expected_127.diff
@@ -1,17 +1,12 @@
 diff --git a/BLAH-127.yaml b/BLAH-127.yaml
-index 4db0978..69afc72 100644
+index 4db0978..4ec2668 100644
 --- a/BLAH-127.yaml
 +++ b/BLAH-127.yaml
-@@ -12,6 +12,15 @@ affects:
+@@ -12,6 +12,10 @@ affects:
    - type: GIT
      repo: https://osv-test/repo/url
      fixed: 8d8242f545e9cec3e6d0d2e3f5bde8be1c659735
-+  - type: GIT
-+    repo: https://osv-test/repo/url
-+    fixed: b9b3fd4732695b83c3068b7b6a14bb372ec31f98
 +  versions:
-+  - branch-v0.1.1
-+  - branch_1_cherrypick_regress
 +  - v0.1
 +  - v0.1.1
 +modified: '2021-01-01T00:00:00Z'

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -650,19 +650,12 @@ class ImpactTest(unittest.TestCase):
             'purl': None,
             'related': [],
             'withdrawn': None,
-            'affected': [
-                'branch-v0.1.1', 'branch-v0.1.1-with-fix',
-                'branch_1_cherrypick_regress', 'v0.1.1', 'v0.2'
-            ],
-            'affected_fuzzy': ['0-1-1', '0-1-1', '1', '0-1-1', '0-2'],
+            'affected':
+                ['branch-v0.1.1', 'branch-v0.1.1-with-fix', 'v0.1.1', 'v0.2'],
+            'affected_fuzzy': ['0-1-1', '0-1-1', '0-1-1', '0-2'],
             'affected_ranges': [{
                 'fixed': '',
                 'introduced': 'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
-                'repo_url': 'https://repo.com/repo',
-                'type': 'GIT'
-            }, {
-                'fixed': '',
-                'introduced': 'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
                 'repo_url': 'https://repo.com/repo',
                 'type': 'GIT'
             }],
@@ -702,8 +695,6 @@ class ImpactTest(unittest.TestCase):
       self.assertEqual('project', commit.project)
 
     self.assertCountEqual([
-        'ff8cc32ba60ad9cbb3b23f0a82aad96ebe9ff76b',
-        'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
         '4c155795426727ea05575bd5904321def23c03f4',
         'b1c95a196f22d06fcf80df8c6691cd113d8fefff',
         'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
@@ -1099,17 +1090,10 @@ class UpdateTest(unittest.TestCase):
             'purl': None,
             'related': [],
             'withdrawn': None,
-            'affected': [
-                'branch-v0.1.1', 'branch_1_cherrypick_regress', 'v0.1', 'v0.1.1'
-            ],
-            'affected_fuzzy': ['0-1-1', '1', '0-1', '0-1-1'],
+            'affected': ['v0.1', 'v0.1.1'],
+            'affected_fuzzy': ['0-1', '0-1-1'],
             'affected_ranges': [{
                 'fixed': '8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
-                'introduced': '',
-                'repo_url': 'https://osv-test/repo/url',
-                'type': 'GIT'
-            }, {
-                'fixed': 'b9b3fd4732695b83c3068b7b6a14bb372ec31f98',
                 'introduced': '',
                 'repo_url': 'https://osv-test/repo/url',
                 'type': 'GIT'
@@ -1150,17 +1134,6 @@ class UpdateTest(unittest.TestCase):
         'eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
         'a2ba949290915d445d34d0e8e9de2e7ce38198fc',
         'e1b045257bc5ca2a11d0476474f45ef77a0366c7',
-        '00514d6f244f696e750a37083163992c6a50cfd3',
-        '25147a74d8aeb27b43665530ee121a2a1b19dc58',
-        '3c5dcf6a5bec14baab3b247d369a7270232e1b83',
-        '4c155795426727ea05575bd5904321def23c03f4',
-        '57e58a5d7c2bb3ce0f04f17ec0648b92ee82531f',
-        '90aa4127295b2c37b5f7fcf6a9772b12c99a5212',
-        '949f182716f037e25394bbb98d39b3295d230a29',
-        'b1fa81a5d59e9b4d6e276d82fc17058f3cf139d9',
-        'f0cc40d8c3dabb27c2cfe26f1764305abc91a0b9',
-        'febfac1940086bc1f6d3dc33fda0a1d1ba336209',
-        'ff8cc32ba60ad9cbb3b23f0a82aad96ebe9ff76b',
     ], [commit.commit for commit in affected_commits])
 
   def test_update_new(self):

--- a/lib/osv/impact.py
+++ b/lib/osv/impact.py
@@ -164,7 +164,6 @@ class RepoAnalyzer:
       if detect_cherrypicks:
         logging.info('Finding equivalent regress commit to %s in %s',
                      regress_commit, ref)
-        # Only actually detect cherrypicks if the input range is complete.
         equivalent_regress_commit = self._get_equivalent_commit(
             repo, ref, regress_commit, detect_cherrypicks=detect_cherrypicks)
       else:
@@ -279,7 +278,7 @@ def _get_commit_to_tag_mappings(repo):
       continue
 
     ref = repo.references[ref_name]
-    mappings.setdefault(str(ref.resolve().target),
+    mappings.setdefault(str(ref.resolve().peel().id),
                         []).append(ref_name[len(TAG_PREFIX):])
 
   return mappings

--- a/lib/osv/impact.py
+++ b/lib/osv/impact.py
@@ -290,7 +290,7 @@ def _get_commit_and_tag_list(repo,
                              commits_to_tags=None,
                              include_start=False,
                              include_end=True):
-  """Get commit list."""
+  """Given a commit range, return the list of commits and tags in the range."""
   logging.info('Getting commits %s..%s', start_commit, end_commit)
   try:
     walker = repo.walk(end_commit,

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -19,7 +19,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='osv',
-    version='0.0.2',
+    version='0.0.3',
     author='OSV authors',
     author_email='osv-discuss@googlegroups.com',
     description='Open Source Vulnerabilities library',


### PR DESCRIPTION
- Simplify impacted tag calculation, by finding them as we
  walk through commit ranges. This also fixes false positives with
  assuming all tags are affected when no "introduced" commit is available.

- Don't compute cherrypicks when the input ranges are incomplete (i.e.
  either no "introduced" or no "fixed"). This leads to inaccurate
  results and potential false positives.

- Throttle AffectedCommit writes to 20000/5 seconds per worker.