### PR TITLE
Vulnfeeds fixes.

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -166,7 +166,6 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (VersionInfo, []str
 	}
 
 	gotVersions := false
-	appendAllVersionsNote := false
 	for _, node := range cve.Configurations.Nodes {
 		if node.Operator != "OR" {
 			continue
@@ -185,7 +184,6 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (VersionInfo, []str
 				var err error
 				introduced, err = nextVersion(validVersions, cleanVersion(match.VersionStartExcluding))
 				if err != nil {
-					appendAllVersionsNote = true
 					notes = append(notes, err.Error())
 				}
 			}
@@ -196,7 +194,6 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (VersionInfo, []str
 				var err error
 				fixed, err = nextVersion(validVersions, cleanVersion(match.VersionEndIncluding))
 				if err != nil {
-					appendAllVersionsNote = true
 					notes = append(notes, err.Error())
 				}
 			}
@@ -207,12 +204,10 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (VersionInfo, []str
 
 			if introduced != "" && !hasVersion(validVersions, introduced) {
 				notes = append(notes, fmt.Sprintf("Warning: %s is not a valid introduced version", introduced))
-				appendAllVersionsNote = true
 			}
 
 			if fixed != "" && !hasVersion(validVersions, fixed) {
 				notes = append(notes, fmt.Sprintf("Warning: %s is not a valid fixed version", fixed))
-				appendAllVersionsNote = true
 			}
 
 			gotVersions = true
@@ -232,10 +227,9 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (VersionInfo, []str
 
 	if len(v.AffectedVersions) == 0 {
 		notes = append(notes, "No versions detected.")
-		appendAllVersionsNote = true
 	}
 
-	if appendAllVersionsNote {
+	if len(notes) != 0 {
 		notes = append(notes, "Valid versions:")
 		for _, version := range validVersions {
 			notes = append(notes, "  - "+version)

--- a/vulnfeeds/pypi/README.md
+++ b/vulnfeeds/pypi/README.md
@@ -8,6 +8,9 @@ the public PyPI dataset.
 bq query --max_rows=10000000 --format=json --nouse_legacy_sql < pypi_links.sql > pypi_links.json
 ```
 
+This is also continuously updated and available at
+<https://storage.googleapis.com/pypa-advisory-db/triage/pypi_links.json>
+
 However this includes packages that no longer exist or were deleted, so we check
 against the [pypi simple API](https://warehouse.pypa.io/api-reference/legacy.html)
 to make sure any matches actually exist.
@@ -18,3 +21,6 @@ We also extract all valid versions by doing:
 ```bash
 bq query --max_rows=10000000 --format=json --nouse_legacy_sql < pypi_versions.sql > pypi_versions.json
 ```
+
+This is also continuously updated and available at
+<https://storage.googleapis.com/pypa-advisory-db/triage/pypi_versions.json>


### PR DESCRIPTION
- Allow matching of multiple packages for a single CVE. Fixes #185.
- Work with normalized package names internally in pypi package.
- Always append note with all valid versions if there are any version
  matching notes.
- Add documentation about continuously updated JSONs.