### PR TITLE
Allow shared IDs between DBs.

### DIFF
--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -57,6 +57,7 @@ class ImporterTest(unittest.TestCase):
         type=osv.SourceRepositoryType.GIT,
         id='oss-fuzz',
         name='oss-fuzz',
+        db_prefix='OSV-',
         repo_url='file://' + self.remote_source_repo_path,
         repo_username='',
         ignore_patterns=['.*IGNORE.*'])
@@ -69,7 +70,7 @@ class ImporterTest(unittest.TestCase):
   def test_basic(self, mock_publish):
     """Test basic run."""
     osv.Bug(
-        id='2017-134',
+        db_id='OSV-2017-134',
         affected=['FILE5_29', 'FILE5_30'],
         affected_fuzzy=['5-29', '5-30'],
         affected_ranges=[{
@@ -133,7 +134,7 @@ class ImporterTest(unittest.TestCase):
             source='oss-fuzz',
             type='update')
     ])
-    bug = osv.Bug.get_by_id('2017-134')
+    bug = osv.Bug.get_by_id('OSV-2017-134')
     self.assertEqual(osv.SourceOfTruth.SOURCE_REPO, bug.source_of_truth)
 
     source_repo = osv.SourceRepository.get_by_id('oss-fuzz')
@@ -187,8 +188,14 @@ class ImporterTest(unittest.TestCase):
     self.mock_repo.add_file('OSV-2021-1338.yaml', '')
     self.mock_repo.commit('OSV', 'infra@osv.dev')
 
+    osv.SourceRepository(
+        type=osv.SourceRepositoryType.GIT,
+        id='source',
+        name='source',
+        repo_url='file://' + self.remote_source_repo_path,
+        repo_username='').put()
     osv.Bug(
-        id='2021-1337',
+        db_id='OSV-2021-1337',
         project='proj',
         ecosystem='OSS-Fuzz',
         status=1,
@@ -196,7 +203,7 @@ class ImporterTest(unittest.TestCase):
         source_of_truth=osv.SourceOfTruth.SOURCE_REPO,
         timestamp=datetime.datetime(2020, 1, 1, 0, 0, 0, 0)).put()
     osv.Bug(
-        id='2021-1338',
+        db_id='OSV-2021-1338',
         project='proj',
         source_id='source:OSV-2021-1338.yaml',
         status=1,
@@ -208,7 +215,7 @@ class ImporterTest(unittest.TestCase):
             'type': 'GIT',
         }]).put()
     osv.Bug(
-        id='2021-1339',
+        db_id='OSV-2021-1339',
         project='proj',
         ecosystem='OSS-Fuzz',
         status=1,
@@ -232,7 +239,7 @@ class ImporterTest(unittest.TestCase):
             type='update'),
         mock.call(
             'projects/oss-vdb/topics/tasks',
-            allocated_id='2021-1339',
+            allocated_id='OSV-2021-1339',
             data=b'',
             source_id='oss-fuzz:124',
             type='impact'),
@@ -251,7 +258,7 @@ class ImporterTest(unittest.TestCase):
     self.mock_repo.add_file('proj/OSV-2021-1337.yaml', '')
     self.mock_repo.commit('OSV', 'infra@osv.dev')
     osv.Bug(
-        id='2021-1337',
+        db_id='OSV-2021-1337',
         project='proj',
         fixed='',
         status=1,

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -359,7 +359,7 @@ class TaskRunner:
         return
 
       bug = osv.Bug(
-          id=vulnerability.id,
+          db_id=vulnerability.id,
           source_id=f'{source_repo.name}:{relative_path}',
           timestamp=osv.utcnow(),
           status=osv.BugStatus.PROCESSED,

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -117,8 +117,10 @@ class ImpactTest(unittest.TestCase):
     tests.mock_clone(self, return_value=pygit2.Repository('osv-test'))
     tests.mock_datetime(self)
 
+    osv.SourceRepository(id='oss-fuzz', name='oss-fuzz', db_prefix='OSV-').put()
+
     allocated_bug = osv.Bug(
-        id='2020-1337',
+        db_id='OSV-2020-1337',
         timestamp=datetime.datetime(2020, 1, 1),
         source_id='oss-fuzz:123',
         status=osv.BugStatus.UNPROCESSED,
@@ -126,8 +128,8 @@ class ImpactTest(unittest.TestCase):
     allocated_bug.put()
 
     should_be_deleted = osv.AffectedCommit(
-        id='2020-1337-abcd',
-        bug_id='2020-1337',
+        id='OSV-2020-1337-abcd',
+        bug_id='OSV-2020-1337',
         commit='abcd',
         project='project',
         ecosystem='ecosystem',
@@ -139,7 +141,7 @@ class ImpactTest(unittest.TestCase):
     message = mock.Mock()
     message.attributes = {
         'source_id': 'oss-fuzz:123',
-        'allocated_id': '2020-1337',
+        'allocated_id': 'OSV-2020-1337',
     }
 
     regress_result = osv.RegressResult(
@@ -169,6 +171,7 @@ class ImpactTest(unittest.TestCase):
     oss_fuzz.process_impact_task('oss-fuzz:123', message)
     self.assertDictEqual(
         {
+            'db_id': 'OSV-2020-1337',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -221,7 +224,7 @@ class ImpactTest(unittest.TestCase):
             'semver_fixed_indexes': [],
             'source': 'oss-fuzz',
         },
-        ndb.Key(osv.Bug, '2020-1337').get()._to_dict())
+        ndb.Key(osv.Bug, 'OSV-2020-1337').get()._to_dict())
 
     affected_commits = list(osv.AffectedCommit.query())
     for commit in affected_commits:
@@ -240,7 +243,7 @@ class ImpactTest(unittest.TestCase):
     message = mock.Mock()
     message.attributes = {
         'source_id': 'oss-fuzz:123',
-        'allocated_id': '2020-1337',
+        'allocated_id': 'OSV-2020-1337',
     }
 
     regress_result = osv.RegressResult(
@@ -271,6 +274,7 @@ class ImpactTest(unittest.TestCase):
     oss_fuzz.process_impact_task('oss-fuzz:123', message)
     self.assertDictEqual(
         {
+            'db_id': 'OSV-2020-1337',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -319,7 +323,7 @@ class ImpactTest(unittest.TestCase):
             'semver_fixed_indexes': [],
             'source': 'oss-fuzz',
         },
-        ndb.Key(osv.Bug, '2020-1337').get()._to_dict())
+        ndb.Key(osv.Bug, 'OSV-2020-1337').get()._to_dict())
 
     affected_commits = list(osv.AffectedCommit.query())
     for commit in affected_commits:
@@ -340,7 +344,7 @@ class ImpactTest(unittest.TestCase):
     message = mock.Mock()
     message.attributes = {
         'source_id': 'oss-fuzz:123',
-        'allocated_id': '2020-1337',
+        'allocated_id': 'OSV-2020-1337',
     }
 
     regress_result = osv.RegressResult(
@@ -371,6 +375,7 @@ class ImpactTest(unittest.TestCase):
     oss_fuzz.process_impact_task('oss-fuzz:123', message)
     self.assertDictEqual(
         {
+            'db_id': 'OSV-2020-1337',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -419,7 +424,7 @@ class ImpactTest(unittest.TestCase):
             'semver_fixed_indexes': [],
             'source': 'oss-fuzz',
         },
-        ndb.Key(osv.Bug, '2020-1337').get()._to_dict())
+        ndb.Key(osv.Bug, 'OSV-2020-1337').get()._to_dict())
 
     affected_commits = list(osv.AffectedCommit.query())
     for commit in affected_commits:
@@ -442,7 +447,7 @@ class ImpactTest(unittest.TestCase):
     message = mock.Mock()
     message.attributes = {
         'source_id': 'oss-fuzz:123',
-        'allocated_id': '2020-1337',
+        'allocated_id': 'OSV-2020-1337',
     }
 
     regress_result = osv.RegressResult(
@@ -472,6 +477,7 @@ class ImpactTest(unittest.TestCase):
     oss_fuzz.process_impact_task('oss-fuzz:123', message)
     self.assertDictEqual(
         {
+            'db_id': 'OSV-2020-1337',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -517,7 +523,7 @@ class ImpactTest(unittest.TestCase):
             'semver_fixed_indexes': [],
             'source': 'oss-fuzz',
         },
-        ndb.Key(osv.Bug, '2020-1337').get()._to_dict())
+        ndb.Key(osv.Bug, 'OSV-2020-1337').get()._to_dict())
 
     affected_commits = list(osv.AffectedCommit.query())
     for commit in affected_commits:
@@ -536,7 +542,7 @@ class ImpactTest(unittest.TestCase):
     message = mock.Mock()
     message.attributes = {
         'source_id': 'oss-fuzz:123',
-        'allocated_id': '2020-1337',
+        'allocated_id': 'OSV-2020-1337',
     }
 
     regress_result = osv.RegressResult(
@@ -568,6 +574,7 @@ class ImpactTest(unittest.TestCase):
     oss_fuzz.process_impact_task('oss-fuzz:123', message)
     self.assertDictEqual(
         {
+            'db_id': 'OSV-2020-1337',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -620,14 +627,14 @@ class ImpactTest(unittest.TestCase):
             'semver_fixed_indexes': [],
             'source': 'oss-fuzz',
         },
-        ndb.Key(osv.Bug, '2020-1337').get()._to_dict())
+        ndb.Key(osv.Bug, 'OSV-2020-1337').get()._to_dict())
 
   def test_not_fixed(self):
     """Test not fixed bug."""
     message = mock.Mock()
     message.attributes = {
         'source_id': 'oss-fuzz:123',
-        'allocated_id': '2020-1337',
+        'allocated_id': 'OSV-2020-1337',
     }
 
     regress_result = osv.RegressResult(
@@ -646,6 +653,7 @@ class ImpactTest(unittest.TestCase):
     oss_fuzz.process_impact_task('oss-fuzz:123', message)
     self.assertDictEqual(
         {
+            'db_id': 'OSV-2020-1337',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -688,7 +696,7 @@ class ImpactTest(unittest.TestCase):
             'semver_fixed_indexes': [],
             'source': 'oss-fuzz',
         },
-        ndb.Key(osv.Bug, '2020-1337').get()._to_dict())
+        ndb.Key(osv.Bug, 'OSV-2020-1337').get()._to_dict())
 
     affected_commits = list(osv.AffectedCommit.query())
     for commit in affected_commits:
@@ -736,9 +744,10 @@ class MarkBugInvalidTest(unittest.TestCase):
 
   def test_mark_bug_invalid(self):
     """Test mark_bug_invalid."""
-    osv.Bug(id='2021-1', source_id='oss-fuzz:1337').put()
-    osv.AffectedCommit(bug_id='2021-1').put()
-    osv.AffectedCommit(bug_id='2021-1').put()
+    osv.SourceRepository(id='oss-fuzz', name='oss-fuzz', db_prefix='OSV-').put()
+    osv.Bug(db_id='OSV-2021-1', source_id='oss-fuzz:1337').put()
+    osv.AffectedCommit(bug_id='OSV-2021-1').put()
+    osv.AffectedCommit(bug_id='OSV-2021-1').put()
 
     message = mock.Mock()
     message.attributes = {
@@ -748,7 +757,7 @@ class MarkBugInvalidTest(unittest.TestCase):
     }
 
     worker.mark_bug_invalid(message)
-    bug = ndb.Key(osv.Bug, '2021-1').get()
+    bug = ndb.Key(osv.Bug, 'OSV-2021-1').get()
     self.assertEqual(osv.BugStatus.INVALID, bug.status)
 
     commits = list(osv.AffectedCommit.query())
@@ -846,26 +855,27 @@ class UpdateTest(unittest.TestCase):
         type=osv.SourceRepositoryType.GIT,
         id='source',
         name='source',
+        db_prefix='BLAH-',
         repo_url='file://' + self.remote_source_repo_path,
         editable=True,
         repo_username='')
     self.source_repo.put()
 
     osv.Bug(
-        id='BLAH-123',
+        db_id='BLAH-123',
         project='blah.com/package',
         ecosystem='golang',
         source_id='source:BLAH-123.yaml',
         source_of_truth=osv.SourceOfTruth.SOURCE_REPO).put()
     osv.Bug(
-        id='BLAH-124',
+        db_id='BLAH-124',
         regressed='eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
         project='blah.com/package',
         ecosystem='golang',
         source_id='source:BLAH-124.yaml',
         source_of_truth=osv.SourceOfTruth.SOURCE_REPO).put()
     osv.Bug(
-        id='BLAH-125',
+        db_id='BLAH-125',
         regressed='eefe8ec3f1f90d0e684890e810f3f21e8500a4cd',
         fixed='8d8242f545e9cec3e6d0d2e3f5bde8be1c659735',
         project='blah.com/package',
@@ -873,7 +883,7 @@ class UpdateTest(unittest.TestCase):
         source_id='source:BLAH-125.yaml',
         source_of_truth=osv.SourceOfTruth.SOURCE_REPO).put()
     osv.Bug(
-        id='BLAH-127',
+        db_id='BLAH-127',
         project='blah.com/package',
         ecosystem='golang',
         source_id='source:BLAH-127.yaml',
@@ -907,6 +917,7 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
+            'db_id': 'BLAH-123',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -998,6 +1009,7 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
+            'db_id': 'BLAH-124',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -1086,6 +1098,7 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
+            'db_id': 'BLAH-127',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -1164,6 +1177,7 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
+            'db_id': 'BLAH-126',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -1343,6 +1357,7 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
+            'db_id': 'PYSEC-123',
             'aliases': [],
             'purl': None,
             'related': [],
@@ -1412,7 +1427,7 @@ class UpdateTest(unittest.TestCase):
             'semver_fixed_indexes': [],
             'source': 'source',
         },
-        osv.Bug.get_by_id('PYSEC-123')._to_dict())
+        ndb.Key(osv.Bug, 'source:PYSEC-123').get()._to_dict())
 
     affected_commits = list(osv.AffectedCommit.query())
     self.assertCountEqual([
@@ -1442,6 +1457,8 @@ class UpdateTest(unittest.TestCase):
 
     self.assertDictEqual(
         {
+            'db_id':
+                'GO-2021-0085',
             'aliases': ['CVE-2019-16884'],
             'purl':
                 None,
@@ -1521,6 +1538,7 @@ class UpdateTest(unittest.TestCase):
         osv.Bug.get_by_id('GO-2021-0085')._to_dict())
     self.assertDictEqual(
         {
+            'db_id': 'GO-2021-0087',
             'aliases': ['CVE-2019-19921'],
             'purl': None,
             'related': [],

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -161,9 +161,6 @@ class IntegrationTests(unittest.TestCase):
 
   def test_get(self):
     """Test getting a vulnerability."""
-    response = requests.get(_api() + '/v1/vulns/2020-744')
-    self.assert_vuln_equal(self._VULN_744, response.json())
-
     response = requests.get(_api() + '/v1/vulns/OSV-2020-744')
     self.assert_vuln_equal(self._VULN_744, response.json())
 

--- a/gcp/appengine/handlers.py
+++ b/gcp/appengine/handlers.py
@@ -158,14 +158,14 @@ def process_results():
       counters[id_year] = counter
 
     try:
-      cur_id = '{}-{}'.format(counter.key.id(), counter.next_id)
-      logging.info('Allocating OSV-%s.', cur_id)
+      cur_id = 'OSV-{}-{}'.format(counter.key.id(), counter.next_id)
+      logging.info('Allocating %s.', cur_id)
       counter.next_id += 1
 
       # Create the Bug now to avoid races when this cron is run again before the
       # impact task finishes.
       bug = osv.Bug(
-          id=cur_id,
+          db_id=cur_id,
           timestamp=datetime.datetime.utcnow(),
           public=False,
           source_id=key_id,

--- a/lib/osv/models.py
+++ b/lib/osv/models.py
@@ -148,6 +148,9 @@ class Bug(ndb.Model):
   # Very large fake version to use when there is no fix available.
   _NOT_FIXED_SEMVER = '999999.999999.999999'
 
+  # Display ID as used by the source database. The full qualified database that
+  # OSV tracks this as may be different.
+  db_id = ndb.StringProperty()
   # Other IDs this bug is known as.
   aliases = ndb.StringProperty(repeated=True)
   # Related IDs.
@@ -211,6 +214,10 @@ class Bug(ndb.Model):
 
   def id(self):
     """Get the bug ID."""
+    if self.db_id:
+      return self.db_id
+
+    # TODO(ochang): Remove once all existing bugs have IDs migrated.
     if re.match(r'^\d+', self.key.id()):
       return self.OSV_ID_PREFIX + self.key.id()
 
@@ -228,7 +235,11 @@ class Bug(ndb.Model):
   @classmethod
   def get_by_id(cls, vuln_id, *args, **kwargs):
     """Overridden get_by_id to handle OSV allocated IDs."""
-    # OSV allocated bug IDs are stored without the prefix.
+    result = cls.query(cls.db_id == vuln_id).get()
+    if result:
+      return result
+
+    # TODO(ochang): Remove once all exsting bugs have IDs migrated.
     if vuln_id.startswith(cls.OSV_ID_PREFIX):
       vuln_id = vuln_id[len(cls.OSV_ID_PREFIX):]
 
@@ -273,8 +284,26 @@ class Bug(ndb.Model):
     if self.source_id:
       self.source, _ = sources.parse_source_id(self.source_id)
 
+    if not self.source:
+      raise ValueError('Source not specified for Bug.')
+
+    if not self.db_id:
+      raise ValueError('DB ID not specified for Bug.')
+
+    if not self.key:
+      source_repo = get_source_repository(self.source)
+      if not source_repo:
+        raise ValueError(f'Invalid source {self.source}')
+
+      if source_repo.db_prefix and self.db_id.startswith(source_repo.db_prefix):
+        key_id = self.db_id
+      else:
+        key_id = f'{self.source}:{self.db_id}'
+
+      self.key = ndb.Key(Bug, key_id)
+
   def update_from_vulnerability(self, vulnerability):
-    """Set fields from vulnerability."""
+    """Set fields from vulnerability. Does not set the ID."""
     self.summary = vulnerability.summary
     self.details = vulnerability.details
     self.reference_url_types = {
@@ -427,6 +456,8 @@ class SourceRepository(ndb.Model):
   versions_from_repo = ndb.BooleanProperty(default=True)
   # HTTP link prefix.
   link = ndb.StringProperty()
+  # DB prefix, if the database allocates its own.
+  db_prefix = ndb.StringProperty()
 
   def ignore_file(self, file_path):
     """Return whether or not we should be ignoring a file."""

--- a/vulnfeeds/pypi/pypi.go
+++ b/vulnfeeds/pypi/pypi.go
@@ -63,7 +63,17 @@ var linkBlocklist = map[string]bool{
 	"https://bitbucket.org":      true,
 	"https://twitter.com":        true,
 	"https://pypi.org":           true,
+	"https://pypi.org/project":   true,
 	"https://jira.atlassian.com": true,
+	"https://www.python.org":     true,
+	"https://gitee.com":          true,
+	"http://github.com":          true,
+	"http://www.cisco.com":       true,
+	"http://www.redhat.com":      true,
+	"http://www.hp.com":          true,
+	"http://www.oracle.com":      true,
+	"http://www.python.org":      true,
+	"unknown":                    true,
 }
 
 func readOrPanic(path string) []byte {
@@ -122,7 +132,7 @@ func extractVendorProduct(link string) string {
 		return ""
 	}
 
-	return strings.ToLower(parts[1]) + "/" + strings.TrimRight(strings.ToLower(parts[2]), ".git")
+	return strings.ToLower(parts[1]) + "/" + strings.TrimSuffix(strings.ToLower(parts[2]), ".git")
 }
 
 // processLinks takes a pypi_links.json and returns a map of links to list of
@@ -132,7 +142,7 @@ func processLinks(linksSource []pypiLinks) (map[string][]string, map[string][]st
 	links := map[string]map[string]bool{}
 	for _, pkg := range linksSource {
 		for _, link := range pkg.Links {
-			link = strings.TrimRight(link, "/")
+			link = strings.ToLower(strings.TrimSuffix(strings.TrimRight(link, "/"), ".git"))
 			if _, exists := linkBlocklist[link]; exists {
 				continue
 			}
@@ -301,7 +311,7 @@ func (p *PyPI) finalPkgCheck(cve cves.CVE, pkg string, falsePositives *triage.Fa
 
 // matchesPackage checks if a given reference link matches a PyPI package.
 func (p *PyPI) matchesPackage(link string, cve cves.CVE, falsePositives *triage.FalsePositives) string {
-	u, err := url.Parse(link)
+	u, err := url.Parse(strings.ToLower(link))
 	if err != nil {
 		return ""
 	}
@@ -310,7 +320,7 @@ func (p *PyPI) matchesPackage(link string, cve cves.CVE, falsePositives *triage.
 	pathParts := strings.Split(u.Path, "/")
 	for i := len(pathParts); i > 0; i-- {
 		u.Path = strings.Join(pathParts[0:i], "/")
-		fullURL := u.String()
+		fullURL := strings.TrimSuffix(u.String(), ".git")
 
 		pkgs, exists := p.links[fullURL]
 		if !exists {


### PR DESCRIPTION
Some DBs don't allocate their own IDs. Store such `Bug`s with
Datastore IDs of the form `"source:ID"`.

If they do allocate their IDs, the Datastore ID is kept as is if the
prefix is what we expect.

Fixes #174.