### PR TITLE
Simplify semver queries.

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -218,6 +218,17 @@ class IntegrationTests(unittest.TestCase):
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
+            'version': '0.0.0-2017a',
+            'package': {
+                'name': 'github.com/nanobox-io/golang-nanoauth',
+            }
+        }))
+    self.assert_results_equal({'vulns': [self._VULN_GO_2020_0004]},
+                              response.json())
+
+    response = requests.post(
+        _api() + '/v1/query',
+        data=json.dumps({
             'version': '0.0.0-20160722212129-ac0cc4484ad4',
             'package': {
                 'name': 'github.com/nanobox-io/golang-nanoauth',

--- a/gcp/appengine/index.yaml
+++ b/gcp/appengine/index.yaml
@@ -37,7 +37,21 @@ indexes:
     properties:
       - name: status
       - name: project
+      - name: affected_fuzzy
+      - name: public
+
+  - kind: Bug
+    properties:
+      - name: status
+      - name: project
       - name: ecosystem
+      - name: public
+      - name: semver_fixed_indexes
+
+  - kind: Bug
+    properties:
+      - name: status
+      - name: project
       - name: public
       - name: semver_fixed_indexes
 

--- a/lib/osv/semver_index.py
+++ b/lib/osv/semver_index.py
@@ -19,14 +19,24 @@ _PAD_WIDTH = 8
 _FAKE_PRE_WIDTH = 16
 
 
-def parse(version):
-  """Parse a SemVer."""
+def _strip_leading_v(version):
+  """Strip leading v from the version, if any."""
   # Versions starting with "v" aren't valid SemVer, but we handle them just in
   # case.
   if version.startswith('v'):
-    version = version[1:]
+    return version[1:]
 
-  return semver.VersionInfo.parse(version)
+  return version
+
+
+def is_valid(version):
+  """Returns whether or not the version is a valid semver."""
+  return semver.VersionInfo.isvalid(_strip_leading_v(version))
+
+
+def parse(version):
+  """Parse a SemVer."""
+  return semver.VersionInfo.parse(_strip_leading_v(version))
 
 
 def normalize(version):


### PR DESCRIPTION
Previously semver queries were only done if the ecosystem was specified
and was marked as semver.

Simplify this by doing the semver query anyway if the ecosystem isn't
specified.