### PR TITLE
vulnfeeds: Fix git range population.

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -119,6 +119,7 @@ func FromCVE(id string, cve cves.CVEItem, pkg, ecosystem, versionType string, va
 			Type: "GIT",
 			Repo: repo,
 		}
+		gitRange.Events = append(gitRange.Events, Event{Introduced: "0"})
 		for _, commit := range commits {
 			gitRange.Events = append(gitRange.Events, Event{Fixed: commit})
 		}


### PR DESCRIPTION
Git ranges should always have an "introduced": "0" entry.