### PR TITLE
Always output "versions" field even if it's empty.

### DIFF
--- a/lib/osv/sources.py
+++ b/lib/osv/sources.py
@@ -132,17 +132,11 @@ def vulnerability_to_dict(vulnerability):
   if 'affected' not in result:
     return result
 
-  # If no SemVer ranges, output an empty "versions": [] to conform to the spec.
-  has_semver = False
   for affected in result['affected']:
-    has_semver = any(
-        r.get('type') == 'SEMVER' for r in affected.get('ranges', []))
-    if has_semver:
-      break
+    if any(r.get('type') == 'SEMVER' for r in affected.get('ranges', [])):
+      return result
 
-  if has_semver:
-    return result
-
+  # If no SemVer ranges, output an empty "versions": [] to conform to the spec.
   for affected in result['affected']:
     if 'versions' not in affected:
       affected['versions'] = []

--- a/lib/osv/sources.py
+++ b/lib/osv/sources.py
@@ -126,8 +126,17 @@ YamlDumper.add_representer(str, _yaml_str_representer)
 
 def vulnerability_to_dict(vulnerability):
   """Convert Vulnerability to a dict."""
-  return json_format.MessageToDict(
+  result = json_format.MessageToDict(
       vulnerability, preserving_proto_field_name=True)
+
+  if 'affected' not in result:
+    return result
+
+  for affected in result['affected']:
+    if 'versions' not in affected:
+      affected['versions'] = []
+
+  return result
 
 
 def _write_vulnerability_dict(data, output_path):

--- a/lib/osv/sources.py
+++ b/lib/osv/sources.py
@@ -132,6 +132,17 @@ def vulnerability_to_dict(vulnerability):
   if 'affected' not in result:
     return result
 
+  # If no SemVer ranges, output an empty "versions": [] to conform to the spec.
+  has_semver = False
+  for affected in result['affected']:
+    has_semver = any(
+        r.get('type') == 'SEMVER' for r in affected.get('ranges', []))
+    if has_semver:
+      break
+
+  if has_semver:
+    return result
+
   for affected in result['affected']:
     if 'versions' not in affected:
       affected['versions'] = []


### PR DESCRIPTION
This is to conform to the schema requirements and to to pass the
validator (https://github.com/ossf/osv-schema/pull/5) in all cases.