### PR TITLE
Fix osv.dev deployment.

### DIFF
--- a/gcp/appengine/.gcloudignore
+++ b/gcp/appengine/.gcloudignore
@@ -18,3 +18,4 @@ __pycache__/
 # Ignored by the build system
 /setup.cfg
 frontend
+frontend3

--- a/gcp/appengine/app.yaml
+++ b/gcp/appengine/app.yaml
@@ -31,6 +31,10 @@ handlers:
     script: auto
     secure: always
 
+  - url: /v2/.*
+    script: auto
+    secure: always
+
   - url: /cron/.*
     script: auto
     secure: always


### PR DESCRIPTION
- Route /v2/ to the Python server.
- Add frontend3 to gcloudignore to avoid deploying a large number of
  unnecessary files.