### PR TITLE
Initial v2 infinite load implementation

### DIFF
--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -10,6 +10,7 @@
         "@hotwired/turbo": "^7.1.0",
         "@material/data-table": "^13.0.0",
         "@material/layout-grid": "^13.0.0",
+        "@material/mwc-circular-progress": "^0.25.3",
         "@material/mwc-icon": "^0.25.3",
         "@material/mwc-icon-button": "^0.25.3",
         "@material/mwc-textfield": "^0.25.3",
@@ -1862,6 +1863,70 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/circular-progress": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-Gi6Ika8MEZQOT3Qei2NfTj+sRWxCDFjchPM7szNjIKgL2DyH03bHmodQFVcyBFiPWEcWMc/mqVYgGf/XJXs85w==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.261f2db59.0",
+        "@material/base": "14.0.0-canary.261f2db59.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+        "@material/progress-indicator": "14.0.0-canary.261f2db59.0",
+        "@material/rtl": "14.0.0-canary.261f2db59.0",
+        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress/node_modules/@material/animation": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-OjxWJYSRNs4vnPe8NclaNn+TsNc8TR/wHusGtezF5F+wl+5mh+K69BMXAmURtq3idoRg4XaOSC/Ohk1ovD1fMQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress/node_modules/@material/base": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-vy5SQt+jcwwdRFfBvtpVdpULUBujecVUKOXcopaQoi2XIzI5EBHuR4gPN0cd1yfmVEucD6p2fvVv2FJ3Ngr61w==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress/node_modules/@material/feature-targeting": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress/node_modules/@material/progress-indicator": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-qm+zUMvFYhHuVB2OdgWTO/Dv1hMFEdIT3loX5OJMpvQ66l6rez/3F7blwHkm6W4mfuxRS3zdDdYbP5QdFcuHuA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress/node_modules/@material/rtl": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
+      "dependencies": {
+        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress/node_modules/@material/theme": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@material/data-table": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-13.0.0.tgz",
@@ -2073,6 +2138,35 @@
       "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
       "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
       "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/mwc-circular-progress": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-circular-progress/-/mwc-circular-progress-0.25.3.tgz",
+      "integrity": "sha512-ajgSzfdRfq0/sZg0Z5W/ZpgZwD8Ioj59m5ScCPXXdkRoVHf7+8lsD/2Fh4095GfoYE4PWSkXYVlWsQCx+aJbcA==",
+      "dependencies": {
+        "@material/circular-progress": "=14.0.0-canary.261f2db59.0",
+        "@material/mwc-base": "^0.25.3",
+        "@material/theme": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-circular-progress/node_modules/@material/feature-targeting": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/mwc-circular-progress/node_modules/@material/theme": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
@@ -10827,6 +10921,72 @@
         "tslib": "^2.1.0"
       }
     },
+    "@material/circular-progress": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-Gi6Ika8MEZQOT3Qei2NfTj+sRWxCDFjchPM7szNjIKgL2DyH03bHmodQFVcyBFiPWEcWMc/mqVYgGf/XJXs85w==",
+      "requires": {
+        "@material/animation": "14.0.0-canary.261f2db59.0",
+        "@material/base": "14.0.0-canary.261f2db59.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+        "@material/progress-indicator": "14.0.0-canary.261f2db59.0",
+        "@material/rtl": "14.0.0-canary.261f2db59.0",
+        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-OjxWJYSRNs4vnPe8NclaNn+TsNc8TR/wHusGtezF5F+wl+5mh+K69BMXAmURtq3idoRg4XaOSC/Ohk1ovD1fMQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/base": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-vy5SQt+jcwwdRFfBvtpVdpULUBujecVUKOXcopaQoi2XIzI5EBHuR4gPN0cd1yfmVEucD6p2fvVv2FJ3Ngr61w==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/progress-indicator": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-qm+zUMvFYhHuVB2OdgWTO/Dv1hMFEdIT3loX5OJMpvQ66l6rez/3F7blwHkm6W4mfuxRS3zdDdYbP5QdFcuHuA==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
+          "requires": {
+            "@material/theme": "14.0.0-canary.261f2db59.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+            "tslib": "^2.1.0"
+          }
+        }
+      }
+    },
     "@material/data-table": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-13.0.0.tgz",
@@ -11038,6 +11198,37 @@
           "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
           "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
           "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
+      }
+    },
+    "@material/mwc-circular-progress": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-circular-progress/-/mwc-circular-progress-0.25.3.tgz",
+      "integrity": "sha512-ajgSzfdRfq0/sZg0Z5W/ZpgZwD8Ioj59m5ScCPXXdkRoVHf7+8lsD/2Fh4095GfoYE4PWSkXYVlWsQCx+aJbcA==",
+      "requires": {
+        "@material/circular-progress": "=14.0.0-canary.261f2db59.0",
+        "@material/mwc-base": "^0.25.3",
+        "@material/theme": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "@material/feature-targeting": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "14.0.0-canary.261f2db59.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
+          "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
             "tslib": "^2.1.0"
           }
         }

--- a/gcp/appengine/frontend3/package.json
+++ b/gcp/appengine/frontend3/package.json
@@ -11,6 +11,7 @@
     "@hotwired/turbo": "^7.1.0",
     "@material/data-table": "^13.0.0",
     "@material/layout-grid": "^13.0.0",
+    "@material/mwc-circular-progress": "^0.25.3",
     "@material/mwc-icon": "^0.25.3",
     "@material/mwc-icon-button": "^0.25.3",
     "@material/mwc-textfield": "^0.25.3",

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -1,4 +1,5 @@
 import './styles.scss';
+import '@material/mwc-circular-progress';
 import '@material/mwc-icon';
 import '@material/mwc-icon-button';
 import '@material/mwc-textfield';

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -176,10 +176,24 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
 
 .vuln-table-container {
   // The vulnerability list should be full-width but not overflow the page bounds.
-  @include full-width;
+  overflow-x: scroll;
+  width: 100%;
+
+  // Apply table display etc.
   .vuln-table {
-    overflow-x: scroll;
-    width: 100%;
+    display: table;
+  }
+  .vuln-table-header {
+    display: table-header-group;
+  }
+  .vuln-table-rows {
+    display: table-row-group;
+  }
+  .vuln-table-row {
+    display: table-row;
+  }
+  .vuln-table-cell {
+    display: table-cell;
   }
 }
 

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -205,6 +205,7 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
   }
   .vuln-table-cell {
     display: table-cell;
+    vertical-align: middle;
   }
 
   // Swap next page button/loading indicator as needed.

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -57,7 +57,7 @@ body {
   color: $osv-text-color;
   font-family: $osv-font-family;
   font-size: 14px;
-  --mdc-theme-primary: $osv-text-color;
+  --mdc-theme-primary: #{$osv-text-color};
   --mdc-theme-surface: $osv-background;
   --mdc-theme-background: $osv-background;
   --mdc-typography-font-family: $osv-font-family;
@@ -78,6 +78,17 @@ pre {
 
 turbo-frame {
   display: contents;
+}
+
+.link-button {
+  display: inline-flex;
+  padding: 0 16px;
+  height: 36px;
+  background: $osv-accent-color;
+  color: $osv-text-color;
+  border-radius: 4px;
+  align-items: center;
+  text-decoration: none;
 }
 
 /** WIP notice */
@@ -194,6 +205,15 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
   }
   .vuln-table-cell {
     display: table-cell;
+  }
+
+  // Swap next page button/loading indicator as needed.
+  turbo-frame .next-page-indicator,
+  turbo-frame[busy] .next-page-button {
+    display: none;
+  }
+  turbo-frame[busy] .next-page-indicator {
+    display: block;
   }
 }
 

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -70,7 +70,7 @@ data-column-id="{{ column_id }}"
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
         </div>
         {% endfor %}
-        <turbo-frame id="vulnerability-table-page{{ page+1 }}" data-turbo-action="advance" target="_top">
+        <turbo-frame id="vulnerability-table-page{{ page + 1 }}" data-turbo-action="advance" target="_top">
           <div class="next-page-container">
             <a class="next-page-button link-button" href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}" data-turbo-frame="_self">Load more...</a>
             <mwc-circular-progress class="next-page-indicator" indeterminate density="-4"></mwc-circular-progress>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -34,12 +34,6 @@ data-column-id="{{ column_id }}"
     </div>
   </div>
 </div>
-<div class="mdc-layout-grid__cell--span-12">
-  Pages
-  <a href="{{ url_for(request.endpoint) }}?page=1" data-turbo-frame="vulnerability-table">1</a>
-  <a href="{{ url_for(request.endpoint) }}?page=2" data-turbo-frame="vulnerability-table">2</a>
-  <a href="{{ url_for(request.endpoint) }}?page=3" data-turbo-frame="vulnerability-table">3</a>
-</div>
 <div class="vuln-table-container mdc-data-table">
   <div role="table" class="vuln-table mdc-data-table__table" aria-label="Vulnerability table">
     <div role="rowgroup" class="vuln-table-header">
@@ -53,7 +47,7 @@ data-column-id="{{ column_id }}"
       </div>
     </div>
     <div role="rowgroup" class="vuln-table-rows mdc-data-table__content">
-      <turbo-frame id="vulnerability-table" data-turbo-action="advance" target="_top">
+      <turbo-frame id="vulnerability-table-page{{ page }}" data-turbo-action="advance" target="_top">
         {% for vulnerability in vulnerabilities %}
         <div role="row" class="vuln-table-row mdc-data-table__row">
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
@@ -76,6 +70,11 @@ data-column-id="{{ column_id }}"
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
         </div>
         {% endfor %}
+        <turbo-frame id="vulnerability-table-page{{ page+1 }}" data-turbo-action="advance" target="_top">
+          <div role="row" class="vuln-table-row mdc-data-table__row">
+            <a href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}" data-turbo-frame="_self">Load more...</a>
+          </div>
+        </turbo-frame>
       </turbo-frame>
     </div>
   </table>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -78,8 +78,7 @@ data-column-id="{{ column_id }}"
         </turbo-frame>
       </turbo-frame>
     </div>
-  </table>
-</div>
+  </div>
 </div>
 </div>
 {% endblock %}

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -71,8 +71,9 @@ data-column-id="{{ column_id }}"
         </div>
         {% endfor %}
         <turbo-frame id="vulnerability-table-page{{ page+1 }}" data-turbo-action="advance" target="_top">
-          <div role="row" class="vuln-table-row mdc-data-table__row">
-            <a href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}" data-turbo-frame="_self">Load more...</a>
+          <div class="next-page-container">
+            <a class="next-page-button link-button" href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}" data-turbo-frame="_self">Load more...</a>
+            <mwc-circular-progress class="next-page-indicator" indeterminate density="-4"></mwc-circular-progress>
           </div>
         </turbo-frame>
       </turbo-frame>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -2,8 +2,8 @@
 {% set active_section = 'vulnerabilities' %}
 
 {% macro table_header_cell(column_id, column_name) %}
-<th
-class="mdc-data-table__header-cell mdc-data-table__header-cell--with-sort"
+<span
+class="vuln-table-cell mdc-data-table__header-cell mdc-data-table__header-cell--with-sort"
 role="columnheader"
 scope="col"
 aria-sort="none"
@@ -18,11 +18,12 @@ data-column-id="{{ column_id }}"
   <div class="mdc-data-table__sort-status-label" aria-hidden="true" id="{{ column_id }}-status-label">
   </div>
 </div>
-</th>
+</span>
 {% endmacro %}
 
 {% block content %}
-<div class="mdc-layout-grid list-page">
+<div class="list-page">
+<div class="mdc-layout-grid">
   <div class="mdc-layout-grid__inner">
     <div class="mdc-layout-grid__cell--span-8">
       <h1 class="title">Vulnerability Library</h1>
@@ -31,56 +32,54 @@ data-column-id="{{ column_id }}"
         <mwc-textfield label="Package or ID search" icon="a" class="search-field"></mwc-textfield>
       </div>
     </div>
-    <turbo-frame id="vulnerability-table" data-turbo-action="advance" target="_top">
-      <div class="mdc-layout-grid__cell--span-12">
-        Pages
-        <a href="{{ url_for(request.endpoint) }}?page=1" data-turbo-frame="_self">1</a>
-        <a href="{{ url_for(request.endpoint) }}?page=2" data-turbo-frame="_self">2</a>
-        <a href="{{ url_for(request.endpoint) }}?page=3" data-turbo-frame="_self">3</a>
-      </div>
-      <div class="mdc-layout-grid__cell--span-12">
-        <div class="vuln-table-container">
-          <div class="vuln-table mdc-data-table">
-            <table class="mdc-data-table__table" aria-label="Dessert calories">
-              <thead>
-                <tr class="mdc-data-table__header-row">
-                  {{ table_header_cell('id', 'ID') }}
-                  {{ table_header_cell('package', 'Packages') }}
-                  {{ table_header_cell('summary', 'Summary') }}
-                  {{ table_header_cell('affected-versions', 'Affected versions') }}
-                  {{ table_header_cell('ecosystem', 'Ecosystem') }}
-                  {{ table_header_cell('last-modified', 'Last modified') }}
-                </tr>
-              </thead>
-              <tbody class="mdc-data-table__content">
-                {% for vulnerability in vulnerabilities %}
-                <tr class="mdc-data-table__row">
-                  <td class="mdc-data-table__cell">
-                    <a href="{{ url_for('frontend_handlers.vulnerability', id=vulnerability.id) }}">{{ vulnerability.id }}</a>
-                  </td>
-                  <td class="mdc-data-table__cell">
-                    {% for package in vulnerability.packages %}
-                    {{ package }}
-                    {% endfor %}
-                  </td>
-                  <td class="mdc-data-table__cell">
-                    {{ vulnerability.summary }}
-                  </td>
-                  <td class="mdc-data-table__cell">
-                    {% for version in vulnerability.versions %}
-                    {{ version }}
-                    {% endfor %}
-                  </td>
-                  <td class="mdc-data-table__cell"></td>
-                  <td class="mdc-data-table__cell"></td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </turbo-frame>
   </div>
+</div>
+<div class="mdc-layout-grid__cell--span-12">
+  Pages
+  <a href="{{ url_for(request.endpoint) }}?page=1" data-turbo-frame="vulnerability-table">1</a>
+  <a href="{{ url_for(request.endpoint) }}?page=2" data-turbo-frame="vulnerability-table">2</a>
+  <a href="{{ url_for(request.endpoint) }}?page=3" data-turbo-frame="vulnerability-table">3</a>
+</div>
+<div class="vuln-table-container mdc-data-table">
+  <div role="table" class="vuln-table mdc-data-table__table" aria-label="Vulnerability table">
+    <div role="rowgroup" class="vuln-table-header">
+      <div role="row" class="vuln-table-row mdc-data-table__header-row">
+        {{ table_header_cell('id', 'ID') }}
+        {{ table_header_cell('package', 'Packages') }}
+        {{ table_header_cell('summary', 'Summary') }}
+        {{ table_header_cell('affected-versions', 'Affected versions') }}
+        {{ table_header_cell('ecosystem', 'Ecosystem') }}
+        {{ table_header_cell('last-modified', 'Last modified') }}
+      </div>
+    </div>
+    <div role="rowgroup" class="vuln-table-rows mdc-data-table__content">
+      <turbo-frame id="vulnerability-table" data-turbo-action="advance" target="_top">
+        {% for vulnerability in vulnerabilities %}
+        <div role="row" class="vuln-table-row mdc-data-table__row">
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            <a href="{{ url_for('frontend_handlers.vulnerability', id=vulnerability.id) }}">{{ vulnerability.id }}</a>
+          </span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            {% for package in vulnerability.packages %}
+            {{ package }}
+            {% endfor %}
+          </span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            {{ vulnerability.summary }}
+          </span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            {% for version in vulnerability.versions %}
+            {{ version }}
+            {% endfor %}
+          </span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
+        </div>
+        {% endfor %}
+      </turbo-frame>
+    </div>
+  </table>
+</div>
+</div>
 </div>
 {% endblock %}

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -100,7 +100,7 @@ def list():
         "versions": item['affected'][0]['versions']
     })
 
-  return render_template('list.html', vulnerabilities=vulnerabilities)
+  return render_template('list.html', page=page, vulnerabilities=vulnerabilities)
 
 
 @blueprint.route('/v2/vulnerability/<id>')

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -100,7 +100,8 @@ def list():
         "versions": item['affected'][0]['versions']
     })
 
-  return render_template('list.html', page=page, vulnerabilities=vulnerabilities)
+  return render_template(
+      'list.html', page=page, vulnerabilities=vulnerabilities)
 
 
 @blueprint.route('/v2/vulnerability/<id>')


### PR DESCRIPTION
This PR introduces an initial "infinite load" (as opposed to "infinite scroll") implementation on the vulnerability table, replacing the previous placeholder pagination.

It does not attempt to fix other known issues with the table e.g. columns aren't complete, width goes out of bounds, etc.

![79q4QkjzVejBbhQ](https://user-images.githubusercontent.com/79461/152505727-4a9939f4-df8e-4339-a64e-491ca1fde889.png)

## Notes

This implementation adds no additional custom JS by taking advantage of `<turbo-frame>`, **part of the pre-existing dependency on Turbo**, which replaces only itself—and not the full page—with an updated version upon request load.

For example, the HTML in `/list?page=1` looks like the following:

```html
<turbo-frame id="vulnerability-page-1">
  vuln 1
  vuln 2
  ..
  vuln n
  <turbo-frame id="vulnerability-page-2">
    <a href="/list?page=2">Load more</a>
  </turbo-frame>
</turbo-frame>
```

Similarly, the HTML in `/list?page=2` looks like the following:

```html
<turbo-frame id="vulnerability-page-2">
  vuln 1
  vuln 2
  ..
  vuln n
  <turbo-frame id="vulnerability-page-3">
    <a href="/list?page=3">Load more</a>
  </turbo-frame>
</turbo-frame>
```

Note how everything is nearly the same, except `id`s attached to the `<turbo-frame>`.

When clicking the link on page 1, this is intercepted by `<turbo-frame id="vulnerability-page-2">`, which fetches `/list?page=2` and looks for a frame with the same id. It then replaces itself with those contents.

Hence the resulting rendered HTML of:

```html
<turbo-frame id="vulnerability-page-1">
  vuln 1
  vuln 2
  ..
  vuln n
  <turbo-frame id="vulnerability-page-2">
    vuln 1
    vuln 2
    ..
    vuln n
    <turbo-frame id="vulnerability-page-3">
      <a href="/list?page=3">Load more</a>
    </turbo-frame>
  </turbo-frame>
</turbo-frame>
```

Ignoring the existence of `<turbo-frame>`, we can also see how this HTML would enable navigation even in web browsers [without custom elements support](https://caniuse.com/?search=Custom%20Elements).

## Known issues

- Unfortunately, `<table>` does not support `<turbo-frame>` wrapping table rows. This is invalid HTML. Adopting this solution was only possible by first rewriting the vulnerability table using `<div>` and `<span>` elements, and using CSS to display it as a table, and ARIA markup for proper screen reader support.
  - In order for the `<turbo-frame>` to not affect the structure of the table, we take advantage of [`display: contents;`](https://caniuse.com/css-display-contents) so that the *rendered* structure of the page is as if all table rows had the same parent.
- The case of the last page isn't handled.

## Further reading

- Turbo Frames documentation: https://turbo.hotwired.dev/handbook/frames
- Prior art for infinite loading/scroll using Turbo: https://lewisyoul.github.io/infinitely-scrolling-lists-with-hotwire-and-zero-javascript