### PR TITLE
Initial v2 search and ecosystem filtering UI

### DIFF
--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -15,6 +15,7 @@
         "@material/mwc-icon-button": "^0.25.3",
         "@material/mwc-textfield": "^0.25.3",
         "@material/theme": "^13.0.0",
+        "lit": "^2.0.0",
         "spicy-sections": "git+https://github.com/tabvengers/spicy-sections.git#1b0f4850bdc5e87a5272b709f353472ed0a05284"
       },
       "devDependencies": {

--- a/gcp/appengine/frontend3/package.json
+++ b/gcp/appengine/frontend3/package.json
@@ -16,6 +16,7 @@
     "@material/mwc-icon-button": "^0.25.3",
     "@material/mwc-textfield": "^0.25.3",
     "@material/theme": "^13.0.0",
+    "lit": "^2.0.0",
     "spicy-sections": "git+https://github.com/tabvengers/spicy-sections.git#1b0f4850bdc5e87a5272b709f353472ed0a05284"
   },
   "devDependencies": {

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -44,10 +44,9 @@ export class MwcTextFieldWithEnter extends MwcTextField {
   constructor() {
     super();
     this.addEventListener('keyup', (e) => {
-      if (e.key !== 'Enter') {
-        return;
+      if (e.key === 'Enter') {
+        submitForm(this.closest('form'));
       }
-      submitForm(this.closest('form'));
     });
   }
 }

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -22,6 +22,8 @@ export class MwcTextFieldWithEnter extends MwcTextField {
       const form = this.closest('form');
       if (form) {
         e.preventDefault();
+        // Make a fake input and submit it. If the actual form is submitted,
+        // Turbo won't intercept the event.
         const fakeSubmit = document.createElement('input');
         fakeSubmit.type = 'submit';
         fakeSubmit.style.display = 'none';

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -5,10 +5,38 @@ import '@material/mwc-icon-button';
 import '@hotwired/turbo';
 import 'spicy-sections/src/SpicySections';
 import {TextField as MwcTextField} from '@material/mwc-textfield';
+import {LitElement, html} from 'lit';
 
 import {MDCDataTable} from '@material/data-table';
 const dataTable = new MDCDataTable(document.querySelector('.mdc-data-table'));
 console.log('dataTable', dataTable);
+
+// Submits a form in a way such that Turbo can intercept the event.
+// Triggering submit on the form directly would still give a correct resulting
+// page, but we want to let Turbo speed up renders as intended.
+const submitForm = function(form) {
+  if (!form) {
+    return;
+  }
+  const fakeSubmit = document.createElement('input');
+  fakeSubmit.type = 'submit';
+  fakeSubmit.style.display = 'none';
+  form.appendChild(fakeSubmit);
+  fakeSubmit.click();
+  fakeSubmit.remove();
+}
+
+// A wrapper around <input type=radio> elements that submits their parent form
+// when any radio item changes.
+export class SubmitRadiosOnClickContainer extends LitElement {
+  constructor() {
+    super();
+    this.addEventListener('change', () => submitForm(this.closest('form')))
+  }
+  // Render the contents of the element as-is.
+  render() { return html`<slot></slot>`; }
+}
+customElements.define('submit-radios', SubmitRadiosOnClickContainer);
 
 // A wrapper around <mwc-textfield> that adds back native-like enter key form
 // submission behavior.
@@ -19,18 +47,7 @@ export class MwcTextFieldWithEnter extends MwcTextField {
       if (e.key !== 'Enter') {
         return;
       }
-      const form = this.closest('form');
-      if (form) {
-        e.preventDefault();
-        // Make a fake input and submit it. If the actual form is submitted,
-        // Turbo won't intercept the event.
-        const fakeSubmit = document.createElement('input');
-        fakeSubmit.type = 'submit';
-        fakeSubmit.style.display = 'none';
-        form.appendChild(fakeSubmit);
-        fakeSubmit.click();
-        fakeSubmit.remove();
-      }
+      submitForm(this.closest('form'));
     });
   }
 }

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -2,10 +2,34 @@ import './styles.scss';
 import '@material/mwc-circular-progress';
 import '@material/mwc-icon';
 import '@material/mwc-icon-button';
-import '@material/mwc-textfield';
 import '@hotwired/turbo';
 import 'spicy-sections/src/SpicySections';
+import {TextField as MwcTextField} from '@material/mwc-textfield';
 
 import {MDCDataTable} from '@material/data-table';
 const dataTable = new MDCDataTable(document.querySelector('.mdc-data-table'));
 console.log('dataTable', dataTable);
+
+// A wrapper around <mwc-textfield> that adds back native-like enter key form
+// submission behavior.
+export class MwcTextFieldWithEnter extends MwcTextField {
+  constructor() {
+    super();
+    this.addEventListener('keyup', (e) => {
+      if (e.key !== 'Enter') {
+        return;
+      }
+      const form = this.closest('form');
+      if (form) {
+        e.preventDefault();
+        const fakeSubmit = document.createElement('input');
+        fakeSubmit.type = 'submit';
+        fakeSubmit.style.display = 'none';
+        form.appendChild(fakeSubmit);
+        fakeSubmit.click();
+        fakeSubmit.remove();
+      }
+    });
+  }
+}
+customElements.define('mwc-textfield-with-enter', MwcTextFieldWithEnter);

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -76,10 +76,6 @@ pre {
   font-family: $osv-heading-font-family;
 }
 
-turbo-frame {
-  display: contents;
-}
-
 .link-button {
   display: inline-flex;
   padding: 0 16px;
@@ -176,6 +172,11 @@ turbo-frame {
     content: '';
     display: block;
   }
+
+  // Hide the submit button.
+  input[type=submit] {
+    display: none;
+  }
 }
 
 // Hax: Make @material/mwc-icon-button play well with @material/data-table.
@@ -206,6 +207,19 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
   .vuln-table-cell {
     display: table-cell;
     vertical-align: middle;
+  }
+
+  // Busy effect.
+  .vuln-table-rows {
+    transition: filter .3s;
+  }
+  &[busy] .vuln-table-rows {
+    filter: blur(4px);
+  }
+
+  // Turbo frames should not create layout by default.
+  turbo-frame {
+    display: contents;
   }
 
   // Swap next page button/loading indicator as needed.

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -136,11 +136,40 @@ pre {
 
 /** List page */
 
-.list-page .title {
-  font-size: 20px;
+.list-page {
+  .title {
+    font-size: 20px;
+  }
+
+  // Hide the submit button.
+  .search input[type=submit] {
+    display: none;
+  }
 }
 
-.search-container {
+.ecosystems {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+
+  label {
+    font-family: $osv-heading-font-family;
+    padding: 10px 20px;
+    background: #696969;
+    border-radius: 999px;
+  }
+
+  input[type=radio]:checked + label {
+    background: $osv-text-color;
+    color: $osv-background;
+  }
+
+  input[type=radio] {
+    display: none;
+  }
+}
+
+.query-container {
   margin-top: 22px;
   border: 2px solid $osv-text-color;
   border-radius: 8px;
@@ -148,7 +177,7 @@ pre {
   --mdc-text-field-label-ink-color: $osv-text-color;
 
   // Make the inner search field full-width.
-  .search-field {
+  .query-field {
     width: 100%;
   }
 
@@ -171,11 +200,6 @@ pre {
     top: -2px;
     content: '';
     display: block;
-  }
-
-  // Hide the submit button.
-  input[type=submit] {
-    display: none;
   }
 }
 

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -28,13 +28,16 @@ data-column-id="{{ column_id }}"
     <div class="mdc-layout-grid__cell--span-8">
       <h1 class="title">Vulnerability Library</h1>
       <div class="search-container">
-        <mwc-icon class="search-icon">search</mwc-icon>
-        <mwc-textfield label="Package or ID search" icon="a" class="search-field"></mwc-textfield>
+        <form action="{{ url_for('frontend_handlers.list') }}" data-turbo-frame="vulnerability-table">
+          <mwc-icon class="search-icon">search</mwc-icon>
+          <mwc-textfield-with-enter label="Package or ID search" icon="a" class="search-field" name="q" value="{{ query }}"></mwc-textfield-with-enter>
+          <input type="submit">
+        </form>
       </div>
     </div>
   </div>
 </div>
-<div class="vuln-table-container mdc-data-table">
+<turbo-frame class="vuln-table-container mdc-data-table" id="vulnerability-table" data-turbo-action="advance">
   <div role="table" class="vuln-table mdc-data-table__table" aria-label="Vulnerability table">
     <div role="rowgroup" class="vuln-table-header">
       <div role="row" class="vuln-table-row mdc-data-table__header-row">
@@ -79,6 +82,6 @@ data-column-id="{{ column_id }}"
       </turbo-frame>
     </div>
   </div>
-</div>
+</turbo-frame>
 </div>
 {% endblock %}

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -35,7 +35,7 @@ data-column-id="{{ column_id }}"
               <mwc-textfield-with-enter label="Package or ID search" icon="a" class="query-field" name="q" value="{{ query }}"></mwc-textfield-with-enter>
             </div>
           </div>
-          <div class="ecosystems">
+          <submit-radios class="ecosystems">
             {% if ecosystems %}
               {% for ecosystem in ecosystems %}
                 <input type="radio" name="ecosystem" id="ecosystem-radio-{{ loop.index }}"
@@ -43,7 +43,7 @@ data-column-id="{{ column_id }}"
                 <label for="ecosystem-radio-{{ loop.index }}">{{ ecosystem }}</label>
               {% endfor %}
             {% endif %}
-          </div>
+          </submit-radios>
           <input type="submit">
         </form>
       </div>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -25,12 +25,25 @@ data-column-id="{{ column_id }}"
 <div class="list-page">
 <div class="mdc-layout-grid">
   <div class="mdc-layout-grid__inner">
-    <div class="mdc-layout-grid__cell--span-8">
+    <div class="mdc-layout-grid__cell--span-12">
       <h1 class="title">Vulnerability Library</h1>
-      <div class="search-container">
+      <div class="search">
         <form action="{{ url_for('frontend_handlers.list') }}" data-turbo-frame="vulnerability-table">
-          <mwc-icon class="search-icon">search</mwc-icon>
-          <mwc-textfield-with-enter label="Package or ID search" icon="a" class="search-field" name="q" value="{{ query }}"></mwc-textfield-with-enter>
+          <div class="mdc-layout-grid__inner">
+            <div class="query-container mdc-layout-grid__cell--span-8">
+              <mwc-icon class="search-icon">search</mwc-icon>
+              <mwc-textfield-with-enter label="Package or ID search" icon="a" class="query-field" name="q" value="{{ query }}"></mwc-textfield-with-enter>
+            </div>
+          </div>
+          <div class="ecosystems">
+            {% if ecosystems %}
+              {% for ecosystem in ecosystems %}
+                <input type="radio" name="ecosystem" id="ecosystem-radio-{{ loop.index }}"
+                    value="{{ ecosystem }}"{% if selected_ecosystem == ecosystem %} checked{% endif %}>
+                <label for="ecosystem-radio-{{ loop.index }}">{{ ecosystem }}</label>
+              {% endfor %}
+            {% endif %}
+          </div>
           <input type="submit">
         </form>
       </div>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -87,9 +87,10 @@ def index_v2():
 @blueprint.route('/v2/list')
 def list():
   """Main page."""
+  query = request.args.get('q', '')
   page = int(request.args.get('page', 1))
   ecosystem = request.args.get('ecosystem')
-  results = osv_query('', page, False, ecosystem)
+  results = osv_query(query, page, False, ecosystem)
 
   vulnerabilities = []
   for item in results['items']:
@@ -101,7 +102,7 @@ def list():
     })
 
   return render_template(
-      'list.html', page=page, vulnerabilities=vulnerabilities)
+      'list.html', page=page, query=query, vulnerabilities=vulnerabilities)
 
 
 @blueprint.route('/v2/vulnerability/<id>')

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -102,10 +102,16 @@ def list():
     })
 
   # Fetch ecosystems by default. As an optimization, skip when rendering page fragments.
-  ecosystems = osv_get_ecosystems() if not request.headers.get('Turbo-Frame') else None
+  ecosystems = osv_get_ecosystems(
+  ) if not request.headers.get('Turbo-Frame') else None
 
   return render_template(
-      'list.html', page=page, query=query, selected_ecosystem=ecosystem, ecosystems=ecosystems, vulnerabilities=vulnerabilities)
+      'list.html',
+      page=page,
+      query=query,
+      selected_ecosystem=ecosystem,
+      ecosystems=ecosystems,
+      vulnerabilities=vulnerabilities)
 
 
 @blueprint.route('/v2/vulnerability/<id>')


### PR DESCRIPTION
This PR gives functionality to the previously non-working search box, as well as adds a list of ecosystems underneath the searchbox that can be used to filter the results by ecosystem.

It also adds a blur effect when searches and filters are loading (if a full page load is not being performed).

It does not fix the known issue where a version not being set, which is common in many ecosystems including crates.io, NuGet, Go, etc., will cause the page to 500. This will be fixed in an upcoming PR.

![image](https://user-images.githubusercontent.com/79461/153118759-fcafd66f-5462-4070-9169-4236db4287e0.png)
![image](https://user-images.githubusercontent.com/79461/153118772-60fa62fb-f698-4b33-adeb-044491650a0c.png)

## Notes

Alas, with today's PR, the Dream of No Custom JS (apart from the code to init `@material/data-table`) has crumbled into pieces.

There are two things we add custom JS to address:

- Creating a new custom element to **wrap the `<mwc-textfield>` custom element**, and behave exactly the same, except to add back native-like behavior of submitting a form upon pressing the Enter key.
  - While this could be a fix to contribute upstream to Material Web, I current expect it would only be possible to land after the M3 release in late 2022. See material-components/material-web#3050.
- Creating a new custom element to **contain `<input type=radio>` elements**, which causes them to submit the form when changed.
  - This allows the *visual* behavior of looking and behaving like chips that reload the table, but *semantically* implemented as a bog standard series of radio inputs in the search form.

Both of these are implemented as custom elements. We pull in the pre-existing `lit@^2.0.0` dependency that came from Material components, which doesn't increase the size of vendors.js. This cuts down the boilerplate of writing a custom element by a lot.

Use of custom elements lets us avoid worrying about the re-initialization and teardown lifecycle whenever a page load is done via JS, as well as not having to specifically target HTML elements e.g. the pair of `document.getElementById('add-radio-behavior')` and `<div id="add-radio-behavior">`.

Note how both of these uses of custom JS are to address minor behaviors only.

The actual search works without requiring a full page refresh.