### PR TITLE
Tweaks for v2 home and list UI

### DIFF
--- a/gcp/appengine/frontend3/src/base.html
+++ b/gcp/appengine/frontend3/src/base.html
@@ -4,6 +4,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Google+Material+Icons:wght@400;500;700" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Overpass+Mono&family=Overpass:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
   <meta charset="utf-8">
   <title>OSV</title>

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -201,11 +201,6 @@ pre {
     content: '';
     display: block;
   }
-
-  // Hide the submit button.
-  input[type=submit] {
-    display: none;
-  }
 }
 
 // Hax: Make @material/mwc-icon-button play well with @material/data-table.

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -215,6 +215,17 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
   overflow-x: scroll;
   width: 100%;
 
+  // Override MDC table styling.
+  border-width: 0;
+  .mdc-data-table__header-cell {
+    border-bottom-color: $osv-text-color;
+    border-bottom-style: solid;
+    font-family: $osv-heading-font-family;
+  }
+  .mdc-data-table__cell {
+    border-bottom-style: dashed;
+  }
+
   // Apply table display etc.
   .vuln-table {
     display: table;

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -337,3 +337,27 @@ dl.vulnerability-details,
     border-bottom: 1px dashed #fff;
   }
 }
+
+/** Home page */
+
+.home-page {
+  .title {
+    font-size: 60px;
+    line-height: 70px;
+  }
+
+  .explainer {
+    font-size: 20px;
+  }
+
+  .google-backed::after {
+    display: inline;
+    content: 'google';
+    font-family: 'Google Material Icons';
+  }
+
+  .usage-examples .heading {
+    font-size: 60px;
+    text-align: center;
+  }
+}

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -212,7 +212,7 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
 
 .vuln-table-container {
   // The vulnerability list should be full-width but not overflow the page bounds.
-  overflow-x: scroll;
+  overflow-x: auto;
   width: 100%;
 
   // Override MDC table styling.

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -201,6 +201,11 @@ pre {
     content: '';
     display: block;
   }
+
+  // Hide the submit button.
+  input[type=submit] {
+    display: none;
+  }
 }
 
 // Hax: Make @material/mwc-icon-button play well with @material/data-table.

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -4,10 +4,10 @@
 {% block content %}
 <div class="mdc-layout-grid">
   <div class="mdc-layout-grid__inner home-page">
-    <div class="mdc-layout-grid__cell--span-8 hero">
+    <div class="mdc-layout-grid__cell--span-6 hero">
       <h1 class="title">A complete picture of vulnerabilities in your open source dependencies.</h1>
       <div class="explainer">
-        <p>
+        <p class="google-backed">
           An ongoing project backed by Google.
         </p>
         <p>
@@ -16,6 +16,14 @@
           maintenance across major open source ecosystems.
         </p>
       </div>
+      <div class="cta">
+        <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.list') }}">Search Vulnerability Database</a>
+        <a class="cta-secondary" href="#">Learn more</a>
+      </div>
+    </div>
+    <div class="mdc-layout-grid__cell--span-12 usage-examples">
+      <h2 class="heading">Use the API</h2>
+      ...
     </div>
   </div>
 </div>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -80,10 +80,10 @@ data-column-id="{{ column_id }}"
             {{ vulnerability.summary }}
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
-            {% for affected in vulnerability.affected %}
-            {% for version in affected.versions %}
-            {{ version }}
-            {% endfor %}
+            {% for version in vulnerability.affected | map(attribute='versions', default=[]) | sum(start=[]) %}
+              {{ version }}
+            {% else %}
+              See details.
             {% endfor %}
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -60,6 +60,8 @@ data-column-id="{{ column_id }}"
         {{ table_header_cell('affected-versions', 'Affected versions') }}
         {{ table_header_cell('ecosystem', 'Ecosystem') }}
         {{ table_header_cell('last-modified', 'Last modified') }}
+        {{ table_header_cell('fixed', 'Fix') }}
+        {{ table_header_cell('severity', 'Severity') }}
       </div>
     </div>
     <div role="rowgroup" class="vuln-table-rows mdc-data-table__content">
@@ -83,6 +85,10 @@ data-column-id="{{ column_id }}"
             {{ version }}
             {% endfor %}
             {% endfor %}
+          </span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            {{ vulnerability.modified }}
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -70,16 +70,18 @@ data-column-id="{{ column_id }}"
             <a href="{{ url_for('frontend_handlers.vulnerability', id=vulnerability.id) }}">{{ vulnerability.id }}</a>
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
-            {% for package in vulnerability.packages %}
-            {{ package }}
+            {% for affected in vulnerability.affected %}
+            {{ affected.package.ecosystem }}/{{ affected.package.name }}
             {% endfor %}
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
             {{ vulnerability.summary }}
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
-            {% for version in vulnerability.versions %}
+            {% for affected in vulnerability.affected %}
+            {% for version in affected.versions %}
             {{ version }}
+            {% endfor %}
             {% endfor %}
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -92,15 +92,6 @@ def list():
   ecosystem = request.args.get('ecosystem')
   results = osv_query(query, page, False, ecosystem)
 
-  vulnerabilities = []
-  for item in results['items']:
-    vulnerabilities.append({
-        "id": item['id'],
-        "summary": item['summary'] if 'summary' in item else '',
-        "packages": item['affected'][0]['package']['ecosystem'],
-        "versions": item['affected'][0]['versions']
-    })
-
   # Fetch ecosystems by default. As an optimization, skip when rendering page fragments.
   ecosystems = osv_get_ecosystems(
   ) if not request.headers.get('Turbo-Frame') else None
@@ -111,7 +102,7 @@ def list():
       query=query,
       selected_ecosystem=ecosystem,
       ecosystems=ecosystems,
-      vulnerabilities=vulnerabilities)
+      vulnerabilities=results['items'])
 
 
 @blueprint.route('/v2/vulnerability/<id>')


### PR DESCRIPTION
This PR makes some visual tweaks to the home and list pages. (Preliminary work on homepage. Vulnerability list table has received border restyling. Last modified column has been added.)

This PR also makes some fixes to the list page. (Package names are now properly listed albeit with no character limit. Versions will display "See details" like v1 instead of 500ing the page if there are none available.)

<img width="1679" alt="Screen Shot 2022-02-10 at 9 10 01 pm" src="https://user-images.githubusercontent.com/79461/153406124-12c637f4-facf-4603-a5f0-bde35b96c1ed.png">
