### PR TITLE
Properly support "withdrawn".

### DIFF
--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """OSV Worker."""
 import argparse
+import datetime
 import json
 import logging
 import os
@@ -167,6 +168,7 @@ def mark_bug_invalid(message):
     logging.error('Bug with source id %s does not exist.', source_id)
     return
 
+  bug.withdrawn = datetime.datetime.utcnow()
   bug.status = osv.BugStatus.INVALID
   bug.put()
 

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -82,18 +82,6 @@ class IntegrationTests(unittest.TestCase):
       'summary': 'Heap-double-free in mrb_default_allocf',
   }
 
-  _VULN_2258 = {
-      'published': '2020-12-11T00:00:45.856Z',
-      'schema_version': '1.2.0',
-      'details': 'INVALID',
-      'id': 'OSV-2020-2258',
-      'references': [{
-          'type': 'REPORT',
-          'url': 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28505',
-      }],
-      'summary': 'Heap-buffer-overflow in grk::t1_part1::T1Part1::decompress',
-  }
-
   _VULN_GO_2020_0004 = {
       'schema_version':
           '1.2.0',
@@ -312,11 +300,6 @@ class IntegrationTests(unittest.TestCase):
     """Test getting a vulnerability with multiple packages."""
     response = requests.get(_api() + '/v1/vulns/GO-2020-0015')
     self.assert_vuln_equal(self._VULN_GO_2020_0015, response.json())
-
-  def test_get_invalid(self):
-    """Test getting an invalid vulnerability."""
-    response = requests.get(_api() + '/v1/vulns/OSV-2020-2258')
-    self.assert_vuln_equal(self._VULN_2258, response.json())
 
   def test_query_commit(self):
     """Test querying by commit."""

--- a/gcp/functions/pypi/testdata/test_vuln.json
+++ b/gcp/functions/pypi/testdata/test_vuln.json
@@ -38,14 +38,38 @@
               "introduced": "3.1"
             },
             {
-              "fixed": "3.3.2"
+              "fixed": "3.1.2"
             }
           ]
         }
       ],
       "versions": [
         "3.1",
-        "3.1.1",
+        "3.1.1"
+      ],
+      "database_specific": {
+        "source": "https://github.com/pypa/advisory-db/blob/main/vulns/cryptography/PYSEC-2021-63.yaml"
+      }
+    },
+    {
+      "package": {
+        "name": "cryptography",
+        "ecosystem": "PyPI"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.2"
+            },
+            {
+              "fixed": "3.3.2"
+            }
+          ]
+        }
+      ],
+      "versions": [
         "3.2",
         "3.2.1",
         "3.3",

--- a/lib/osv/models.py
+++ b/lib/osv/models.py
@@ -406,6 +406,9 @@ class Bug(ndb.Model):
 
       self.key = ndb.Key(Bug, key_id)
 
+    if self.withdrawn:
+      self.status = bug.BugStatus.INVALID
+
   def update_from_vulnerability(self, vulnerability):
     """Set fields from vulnerability. Does not set the ID."""
     self.summary = vulnerability.summary
@@ -421,6 +424,8 @@ class Bug(ndb.Model):
       self.timestamp = vulnerability.published.ToDatetime()
     if vulnerability.HasField('withdrawn'):
       self.withdrawn = vulnerability.withdrawn.ToDatetime()
+    else:
+      self.withdrawn = None
 
     self.aliases = list(vulnerability.aliases)
     self.related = list(vulnerability.related)
@@ -534,9 +539,6 @@ class Bug(ndb.Model):
         affected.append(current)
 
     details = self.details
-    if self.status == bug.BugStatus.INVALID:
-      affected = None
-      details = 'INVALID'
 
     if self.last_modified:
       modified = timestamp_pb2.Timestamp()


### PR DESCRIPTION
- Set "withdrawn" vulnerabilities to invalid to prevent them from
  surfacing in API results and UI.
- Handle sending "withdrawn" vulnerabilities to PyPI. Also improve
  version aggregation while we're here.

Fixes #290.