### PR TITLE
Make OSS-Fuzz FixResult setting more accurate.

### DIFF
--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -202,12 +202,9 @@ def add_fix_information(vulnerability, bug, fix_result):
       if affected_range.type != vulnerability_pb2.Range.GIT:
         continue
 
-      # If this range includes the introduced commit, and not the fixed
-      # commit, add it.
-      # Use "in" for the introduced comparison because `bug.regressed` could
-      # be a commit range for OSS-Fuzz bugs.
-      if (any(event.introduced and event.introduced in bug.regressed
-              for event in affected_range.events) and
+      # If this range does not include the fixed commit, add it.
+      # Use the repo URL to key on if the fix commit needs to be added.
+      if (fix_result.repo_url == affected_range.repo and
           not any(event.fixed == fix_commit
                   for event in affected_range.events)):
         added_fix = True

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -677,6 +677,7 @@ class UpdateTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
     """Test basic update adding a fix."""
     fix_result = osv.FixResult(
         id='source:BLAH-124.yaml',
+        repo_url='https://osv-test/repo/url',
         commit='8d8242f545e9cec3e6d0d2e3f5bde8be1c659735')
     fix_result.put()
     task_runner = worker.TaskRunner(ndb_client, None, self.tmp_dir.name, None,


### PR DESCRIPTION
Use the repo URL to key on if a fix commit needs to be added to a git
range.