### PR TITLE
More tweaks for v2 list UI

### DIFF
--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.0.0",
       "dependencies": {
+        "@github/time-elements": "^3.1.2",
         "@hotwired/turbo": "^7.1.0",
         "@material/data-table": "^13.0.0",
         "@material/layout-grid": "^13.0.0",
@@ -1821,6 +1822,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@github/time-elements": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@github/time-elements/-/time-elements-3.1.2.tgz",
+      "integrity": "sha512-YVtZVLBikP6I7na22kfB9PKIseISwX41MFJ7lPuNz1VVH2IR5cpRRU6F1X6kcchPChljuvMUR4OiwMWHOJQ8kQ=="
     },
     "node_modules/@hotwired/turbo": {
       "version": "7.1.0",
@@ -10879,6 +10885,11 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "dev": true
+    },
+    "@github/time-elements": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@github/time-elements/-/time-elements-3.1.2.tgz",
+      "integrity": "sha512-YVtZVLBikP6I7na22kfB9PKIseISwX41MFJ7lPuNz1VVH2IR5cpRRU6F1X6kcchPChljuvMUR4OiwMWHOJQ8kQ=="
     },
     "@hotwired/turbo": {
       "version": "7.1.0",

--- a/gcp/appengine/frontend3/package.json
+++ b/gcp/appengine/frontend3/package.json
@@ -8,6 +8,7 @@
     "build": "webpack"
   },
   "dependencies": {
+    "@github/time-elements": "^3.1.2",
     "@hotwired/turbo": "^7.1.0",
     "@material/data-table": "^13.0.0",
     "@material/layout-grid": "^13.0.0",

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -1,4 +1,5 @@
 import './styles.scss';
+import '@github/time-elements';
 import '@material/mwc-circular-progress';
 import '@material/mwc-icon';
 import '@material/mwc-icon-button';

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -3,6 +3,7 @@
 $osv-background: #292929;
 $osv-text-color: #fff;
 $osv-accent-color: #c5221f;
+$osv-red-300: #ec928e;
 $osv-font-family: string.unquote('Overpass, sans-serif');
 $osv-heading-font-family: string.unquote('"Overpass Mono", monospace');
 
@@ -242,6 +243,36 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
   .vuln-table-cell {
     display: table-cell;
     vertical-align: middle;
+  }
+
+  // Packages list.
+  .packages {
+    margin: 0;
+    padding: 0;
+  }
+
+  // Version list.
+  .versions {
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 50% 50%;
+  }
+  .version {
+    display: block;
+  }
+
+  // Tag styling.
+  .tag {
+    display: inline-block;
+    background: $osv-text-color;
+    color: $osv-background;
+    padding: 0 7px;
+    border-radius: 4px;
+
+    &.fix-unavailable {
+      background: $osv-red-300;
+    }
   }
 
   // Busy effect.

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -72,25 +72,41 @@ data-column-id="{{ column_id }}"
             <a href="{{ url_for('frontend_handlers.vulnerability', id=vulnerability.id) }}">{{ vulnerability.id }}</a>
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            <ul class="packages">
             {% for affected in vulnerability.affected %}
-            {{ affected.package.ecosystem }}/{{ affected.package.name }}
+              <li>{{ affected.package.ecosystem }}/{{ affected.package.name }}</li>
             {% endfor %}
+            </ul>
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
             {{ vulnerability.summary }}
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            <ul class="versions">
             {% for version in vulnerability.affected | map(attribute='versions', default=[]) | sum(start=[]) %}
-              {{ version }}
+              {% if loop.index < 8 %}
+              <li class="version">{{ version }}</li>
+              {% elif loop.index == 8 %}
+              <li class="version">...</li>
+              {% endif %}
             {% else %}
-              See details.
+              <li class="version">See details.</li>
             {% endfor %}
+          </ul>
           </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell">
-            {{ vulnerability.modified }}
+            <relative-time datetime="{{ vulnerability.modified }}">
+              {{ vulnerability.modified }}
+            </relative-time>
           </span>
-          <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
+          <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+            {% if vulnerability.affected | map(attribute='ranges', default=[]) | sum(start=[]) | map(attribute='events', default='') | sum(start=[]) | selectattr('fixed', 'defined') | first %}
+            <span class="tag fix-available">Fix available</span>
+            {% else %}
+            <span class="tag fix-unavailable">No fix available</span>
+            {% endif %}
+          </span>
           <span role="cell" class="vuln-table-cell mdc-data-table__cell"></span>
         </div>
         {% endfor %}


### PR DESCRIPTION
This PR begins work on resolving the ultra-long width vulnerability table with various fixes, and includes some improvements:

- Packages are listed vertically instead of as one continuous string
- Affected versions are displayed in a two-column grid and limited to up-to-8 versions
- Last modified is now displayed as a relative date using GitHub's [`time-elements`](https://github.com/github/time-elements) web components
- "Fix available"/"No fix available" is now displayed

Screenshot:

![8pguHaZvaoKTYLR](https://user-images.githubusercontent.com/79461/155104146-8256b4ff-63b8-40e8-a941-10d98c791ec1.png)