### PR TITLE
Reduce Datastore index fanout.

### DIFF
--- a/gcp/appengine/index.yaml
+++ b/gcp/appengine/index.yaml
@@ -30,13 +30,23 @@ indexes:
       - name: status
       - name: project
       - name: ecosystem
-      - name: affected_fuzzy
       - name: public
 
   - kind: Bug
     properties:
       - name: status
       - name: project
+      - name: public
+
+  - kind: Bug
+    properties:
+      - name: status
+      - name: purl
+      - name: public
+
+  - kind: Bug
+    properties:
+      - name: status
       - name: affected_fuzzy
       - name: public
 
@@ -54,21 +64,6 @@ indexes:
       - name: project
       - name: public
       - name: semver_fixed_indexes
-
-  - kind: Bug
-    properties:
-      - name: status
-      - name: purl
-      - name: ecosystem
-      - name: affected_fuzzy
-      - name: public
-
-  - kind: Bug
-    properties:
-      - name: status
-      - name: purl
-      - name: affected_fuzzy
-      - name: public
 
   - kind: Bug
     properties:


### PR DESCRIPTION
Redefine composite indexes to rely on [zig zag merge](https://cloud.google.com/datastore/docs/concepts/optimize-indexes#index_merge_performance) for queries.
This results in `O(version + package)` indexes instead of
`O(version x package)` indexes per vulnerability.

Also fix a bug with querying by package+version on rare vulnerabilities
with multiple different packages.

Previously we were incorrectly returning matches if a query matches any
listed package and any listed version. Now we filter to make sure the
version actually matches the package.

Fixes #315.