### PR TITLE
Fix missing search box on vulnerability list.

### DIFF
--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -8,10 +8,6 @@ import 'spicy-sections/src/SpicySections';
 import {TextField as MwcTextField} from '@material/mwc-textfield';
 import {LitElement, html} from 'lit';
 
-import {MDCDataTable} from '@material/data-table';
-const dataTable = new MDCDataTable(document.querySelector('.mdc-data-table'));
-console.log('dataTable', dataTable);
-
 // Submits a form in a way such that Turbo can intercept the event.
 // Triggering submit on the form directly would still give a correct resulting
 // page, but we want to let Turbo speed up renders as intended.

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -136,4 +136,8 @@ data-column-id="{{ column_id }}"
   </div>
 </turbo-frame>
 </div>
+<script>
+import {MDCDataTable} from '@material/data-table';
+const dataTable = new MDCDataTable(document.querySelector('.mdc-data-table'));
+</script>
 {% endblock %}


### PR DESCRIPTION
This happens when we start at a different page (e.g. the home page)
and navigate to the vulnerability list page.

This seems to be because the place where we were instantiating the
MDCDataTable (index.js) can be run in a context where the actual element
hasn't been loaded in if we're not on the right page. 

This causes the `mwc-textfield-with-enter` element to not be defined properly,
leading to the missing search box.