### PR TITLE
Initial v2 homepage primary components

### DIFF
--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.0.0",
       "dependencies": {
+        "@github/clipboard-copy-element": "^1.1.2",
         "@github/time-elements": "^3.1.2",
         "@hotwired/turbo": "^7.1.0",
         "@material/data-table": "^13.0.0",
@@ -40,6 +41,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@github/clipboard-copy-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@github/clipboard-copy-element/-/clipboard-copy-element-1.1.2.tgz",
+      "integrity": "sha512-L6CMrcA5we0udafvoSuRCE/Ci/3xrLWKYRGup2IlhxF771bQYsQ2EB1of182pI8ZWM4oxgwzu37+igMeoZjN/A=="
     },
     "node_modules/@github/time-elements": {
       "version": "3.1.2",
@@ -5515,6 +5521,11 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "dev": true
+    },
+    "@github/clipboard-copy-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@github/clipboard-copy-element/-/clipboard-copy-element-1.1.2.tgz",
+      "integrity": "sha512-L6CMrcA5we0udafvoSuRCE/Ci/3xrLWKYRGup2IlhxF771bQYsQ2EB1of182pI8ZWM4oxgwzu37+igMeoZjN/A=="
     },
     "@github/time-elements": {
       "version": "3.1.2",

--- a/gcp/appengine/frontend3/package.json
+++ b/gcp/appengine/frontend3/package.json
@@ -8,6 +8,7 @@
     "build": "webpack"
   },
   "dependencies": {
+    "@github/clipboard-copy-element": "^1.1.2",
     "@github/time-elements": "^3.1.2",
     "@hotwired/turbo": "^7.1.0",
     "@material/data-table": "^13.0.0",

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -1,4 +1,5 @@
 import './styles.scss';
+import '@github/clipboard-copy-element';
 import '@github/time-elements';
 import '@material/mwc-circular-progress';
 import '@material/mwc-icon';

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -156,45 +156,45 @@ pre {
     font-size: 20px;
   }
 
-  // Hide the submit button.
-  .search input[type=submit] {
-    display: none;
-  }
-}
-
-.ecosystems {
-  margin-top: 20px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-
-  .ecosystem-label {
+  .ecosystems {
+    margin-top: 20px;
     display: flex;
-    gap: 16px;
-    font-family: $osv-heading-font-family;
-    padding: 10px 20px;
-    background: #696969;
-    border-radius: 999px;
-
-    .ecosystem-count {
-      font-weight: bold;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+  
+    .ecosystem-label {
+      display: flex;
+      gap: 16px;
+      font-family: $osv-heading-font-family;
+      padding: 10px 20px;
+      background: #696969;
+      border-radius: 999px;
+  
+      .ecosystem-count {
+        font-weight: bold;
+      }
+    }
+  
+    .ecosystems-divider {
+      display: block;
+      margin: 0 10px;
+      height: 30px;
+      border-right: 1px solid $osv-grey-600;
+    }
+  
+    input[type=radio]:checked + .ecosystem-label {
+      background: $osv-text-color;
+      color: $osv-accent-color;
+    }
+  
+    input[type=radio] {
+      display: none;
     }
   }
 
-  .ecosystems-divider {
-    display: block;
-    margin: 0 10px;
-    height: 30px;
-    border-right: 1px solid $osv-grey-600;
-  }
-
-  input[type=radio]:checked + .ecosystem-label {
-    background: $osv-text-color;
-    color: $osv-accent-color;
-  }
-
-  input[type=radio] {
+  // Hide the submit button.
+  .search input[type=submit] {
     display: none;
   }
 }
@@ -469,6 +469,8 @@ dl.vulnerability-details,
   }
 
   .ecosystem-counts {
+    margin-top: 130px;
+
     .ecosystems {
       display: grid;
       grid-template-rows: 30px 210px;
@@ -482,6 +484,8 @@ dl.vulnerability-details,
         top: -30px;
         background: #333;
         height: 100%;
+        // Keep 1:1 ratio of child element.
+        padding-top: 100%;
       }
       .ecosystem-count {
         position: relative;
@@ -498,6 +502,7 @@ dl.vulnerability-details,
   }
 
   .usage-examples {
+    margin-top: 130px;
     margin-bottom: 120px;
     .heading {
       font-size: 60px;

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -84,8 +84,11 @@ a:not([href^="https://osv.dev"]):not([href^="/"])::after {
 }
 
 h1,
+h2,
+h3,
 pre {
   font-family: $osv-heading-font-family;
+  font-weight: normal;
 }
 
 .link-button {
@@ -465,8 +468,83 @@ dl.vulnerability-details,
     font-family: 'Google Material Icons';
   }
 
-  .usage-examples .heading {
-    font-size: 60px;
-    text-align: center;
+  .ecosystem-counts {
+    .ecosystems {
+      display: grid;
+      grid-template-rows: 30px 210px;
+      grid-auto-flow: column;
+      dt {
+        position: relative;
+        top: 210px;
+      }
+      dd {
+        position: relative;
+        top: -30px;
+        background: #333;
+        height: 100%;
+      }
+      .ecosystem-count {
+        position: relative;
+        left: 50%;
+        top: 50%;
+        transform: translateX(-50%) translateY(-50%);
+        display: block;
+        background: #ddd;
+        color: #000;
+        border-radius: 999px;
+        text-align: center;
+      }
+    }
+  }
+
+  .usage-examples {
+    margin-bottom: 120px;
+    .heading {
+      font-size: 60px;
+      text-align: center;
+      margin-bottom: 32px;
+    }
+  }
+
+  .code-card {
+    position: relative;
+    background: #d46d59;
+    border-radius: 10px;
+    padding: 32px;
+
+    .code-card-title {
+      font-size: 32px;
+    }
+
+    .code-card-copy {
+      position: absolute;
+      left: 50%;
+      bottom: 0;
+      transform: translateX(-50%) translateY(50%);
+
+      .icon {
+        background: #fff;
+        border-radius: 999px;
+        color: #d46d59;
+      }
+    }
+  }
+
+  .api-banner {
+    width: 640px;
+    margin: 0 auto;
+
+    .heading {
+      font-size: 28px;
+      line-height: 54px;
+    }
+    .description {
+      font-size: 20px;
+      line-height: 24px;
+    }
+    .cta {
+      margin: 32px 0;
+      text-align: center;
+    }
   }
 }

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -23,7 +23,24 @@
     </div>
     <div class="mdc-layout-grid__cell--span-12 usage-examples">
       <h2 class="heading">Use the API</h2>
-      ...
+      
+      <div class="mdc-layout-grid__inner">
+        <div class="code-card mdc-layout-grid__cell--span-6">
+          <h3 class="code-card-title">Query by commit hash</h3>
+          <pre id="example-commit-hash">curl -X POST -d \
+  '{"commit": "6879efc2c1596d11a6a6ad296f80063b558d5e0f"}' \
+  "https://api.osv.dev/v1/query"</pre>
+          <clipboard-copy for="example-commit-hash">Copy</clipboard-copy>
+        </div>
+        <div class="code-card mdc-layout-grid__cell--span-6">
+          <h3 class="code-card-title">Query by version number</h3>
+          <pre id="example-version-number">curl -X POST -d \
+  '{"version": "2.4.1",
+    "package": {"name": "jinja2", "ecosystem": "PyPI"}}' \
+  "https://api.osv.dev/v1/query"</pre>
+          <clipboard-copy for="example-version-number">Copy</clipboard-copy>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -21,6 +21,35 @@
         <a class="cta-secondary" href="#">Learn more</a>
       </div>
     </div>
+    <div class="mdc-layout-grid__cell--span-12 ecosystem-counts">
+      <h2 class="heading">Our current vulnerability coverage</h2>
+      <dl class="ecosystems">
+        <dt>DWF</dt>
+        <dd>
+          <span class="ecosystem-count" style="width: 142px; height: 142px;">21K</span>
+        </dd>
+        <dt>Go</dt>
+        <dd>
+          <span class="ecosystem-count" style="width: 88px; height: 88px;">12K</span>
+        </dd>
+        <dt>Linux</dt>
+        <dd>
+          <span class="ecosystem-count" style="width: 210px; height: 210px;">26K</span>
+        </dd>
+        <dt>OSS-Fuzz</dt>
+        <dd>
+          <span class="ecosystem-count" style="width: 62px; height: 62px;">5K</span>
+        </dd>
+        <dt>PyPI</dt>
+        <dd>
+          <span class="ecosystem-count" style="width: 124px; height: 124px;">16K</span>
+        </dd>
+        <dt>Crates.io</dt>
+        <dd>
+          <span class="ecosystem-count" style="width: 14px; height: 14px;">1K</span>
+        </dd>
+      </dl>
+    </div>
     <div class="mdc-layout-grid__cell--span-12 usage-examples">
       <h2 class="heading">Use the API</h2>
       
@@ -30,7 +59,9 @@
           <pre id="example-commit-hash">curl -X POST -d \
   '{"commit": "6879efc2c1596d11a6a6ad296f80063b558d5e0f"}' \
   "https://api.osv.dev/v1/query"</pre>
-          <clipboard-copy for="example-commit-hash">Copy</clipboard-copy>
+          <clipboard-copy class="code-card-copy" for="example-commit-hash">
+            <mwc-icon-button class="icon" icon="content_copy"></mwc-icon-button>
+          </clipboard-copy>
         </div>
         <div class="code-card mdc-layout-grid__cell--span-6">
           <h3 class="code-card-title">Query by version number</h3>
@@ -38,8 +69,20 @@
   '{"version": "2.4.1",
     "package": {"name": "jinja2", "ecosystem": "PyPI"}}' \
   "https://api.osv.dev/v1/query"</pre>
-          <clipboard-copy for="example-version-number">Copy</clipboard-copy>
+          <clipboard-copy class="code-card-copy" for="example-version-number">
+            <mwc-icon-button class="icon" icon="content_copy"></mwc-icon-button>
+          </clipboard-copy>
         </div>
+      </div>
+    </div>
+    <div class="mdc-layout-grid__cell--span-12 api-banner">
+      <h2 class="heading">Understand your open source exposure.</h2>
+      <p class="description">
+        Enter a git commit hash or version number and the API
+        returns a list of vulnerabilities affecting that version.
+      </p>
+      <div class="cta">
+        <a class="link-button" href="{{ url_for('frontend_handlers.list_vulnerabilities') }}">To the API</a>
       </div>
     </div>
   </div>

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -24,30 +24,18 @@
     <div class="mdc-layout-grid__cell--span-12 ecosystem-counts">
       <h2 class="heading">Our current vulnerability coverage</h2>
       <dl class="ecosystems">
-        <dt>DWF</dt>
-        <dd>
-          <span class="ecosystem-count" style="width: 142px; height: 142px;">21K</span>
-        </dd>
-        <dt>Go</dt>
-        <dd>
-          <span class="ecosystem-count" style="width: 88px; height: 88px;">12K</span>
-        </dd>
-        <dt>Linux</dt>
-        <dd>
-          <span class="ecosystem-count" style="width: 210px; height: 210px;">26K</span>
-        </dd>
-        <dt>OSS-Fuzz</dt>
-        <dd>
-          <span class="ecosystem-count" style="width: 62px; height: 62px;">5K</span>
-        </dd>
-        <dt>PyPI</dt>
-        <dd>
-          <span class="ecosystem-count" style="width: 124px; height: 124px;">16K</span>
-        </dd>
-        <dt>Crates.io</dt>
-        <dd>
-          <span class="ecosystem-count" style="width: 14px; height: 14px;">1K</span>
-        </dd>
+        {% if ecosystem_counts %}
+          {% set total = ecosystem_counts.values() | sum %}
+          {% for ecosystem in ecosystem_counts %}
+            <dt>{{ ecosystem }}</dt>
+            <dd>
+              <span class="ecosystem-count" style="
+                  width: {{ ecosystem_counts[ecosystem] / total * 100 }}%;">
+                {{ ecosystem_counts[ecosystem] }}
+              </span>
+            </dd>
+          {% endfor %}
+        {% endif %}
       </dl>
     </div>
     <div class="mdc-layout-grid__cell--span-12 usage-examples">

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -77,8 +77,7 @@ def index():
 @blueprint.route('/v2/')
 def index_v2():
   return render_template(
-      'home.html',
-      ecosystem_counts=osv_get_ecosystem_counts())
+      'home.html', ecosystem_counts=osv_get_ecosystem_counts())
 
 
 @blueprint.route('/v2/list')

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -76,7 +76,9 @@ def index():
 
 @blueprint.route('/v2/')
 def index_v2():
-  return render_template('home.html')
+  return render_template(
+      'home.html',
+      ecosystem_counts=osv_get_ecosystem_counts())
 
 
 @blueprint.route('/v2/list')


### PR DESCRIPTION
Adding the ecosystem coverage, code snippets, API link placeholder. Looks pretty broken for now, but let's land this and have a followup PR to clean it up.

Code snippet copy button is working, thanks to GitHub's `<clipboard-copy>` custom element. Adds 5KB to vendors.js.

![localhost_8000_v2_](https://user-images.githubusercontent.com/79461/160843407-7ce3eb81-5882-4815-9456-f15f73d4b968.png)

