### PR TITLE
Improvements to vulnerability page.

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -452,11 +452,38 @@ dl.vulnerability-details,
     font-family: $osv-heading-font-family;
   }
 
+  .versions-section {
+    --const-mq-affordances: [screen] collapse;
+
+    h2.version-header::before {
+      content: '';
+      margin-right: 16px;
+      background: url(/static/img/arrow.png);
+      background-position: center;
+      transform: rotate(0deg);
+    }
+
+    h2.version-header[expanded]::before {
+      transform: rotate(90deg);
+    }
+
+    h2.version-header {
+      background: none;
+      font-family: $osv-heading-font-family;
+      color: #fff;
+      padding-left: 0px;
+      font-size: 16px;
+    }
+  }
+
   .versions {
     display: flex;
     overflow: auto;
     flex-wrap: wrap;
     gap: 8px;
+    padding-bottom: 12px;
+    border-bottom: 1px dashed #fff;
+
   }
 
   .version {
@@ -473,7 +500,7 @@ dl.vulnerability-details,
     pointer-events: none;
   }
 
-  &[affordance="collapse"] h2 {
+  &[affordance="collapse"] h2.package-header {
     .vuln-ecosystem {
       display: inline;
       font-weight: bold;
@@ -492,7 +519,7 @@ dl.vulnerability-details,
     width: 100%;
   }
 
-  &[affordance="tab-bar"] h2 {
+  &[affordance="tab-bar"] h2.package-header {
     cursor: default;
 
     // Default tab spacing of 20px. First tab should match grid margin.

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -436,6 +436,10 @@ dl.vulnerability-details,
     font-size: 14px;
     padding: 16px;
   }
+  
+  h3 {
+    font-family: $osv-body-font-family;
+  }
 
   .subtitle {
     font-family: $osv-heading-font-family;

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -482,8 +482,10 @@ dl.vulnerability-details,
     flex-wrap: wrap;
     gap: 8px;
     padding-bottom: 12px;
-    border-bottom: 1px dashed #fff;
+  }
 
+  .versions-separator {
+    border-bottom: 1px dashed #fff;
   }
 
   .version {

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -379,6 +379,7 @@ dl.vulnerability-details,
   grid-template-columns: max-content minmax(0, auto);
   grid-row-gap: 5px;
   max-width: 1000px;
+  gap: 8px;
 
   dt {
     grid-column: 1;
@@ -439,6 +440,7 @@ dl.vulnerability-details,
   
   h3 {
     font-family: $osv-body-font-family;
+    font-weight: bold;
   }
 
   .subtitle {

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -378,6 +378,7 @@ dl.vulnerability-details,
   display: grid;
   grid-template-columns: max-content minmax(0, auto);
   grid-row-gap: 5px;
+  max-width: 1000px;
 
   dt {
     grid-column: 1;
@@ -443,6 +444,18 @@ dl.vulnerability-details,
 
   .version-value {
     font-family: $osv-heading-font-family;
+  }
+
+  .versions {
+    display: flex;
+    overflow: auto;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .version {
+    width: 100px;
+    overflow-wrap: break-word;
   }
 
   .events {

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -97,7 +97,7 @@
             {% for group, versions in (affected['versions']|group_versions).items() %}
               <spicy-sections class="versions-section">
                 <h2 class="version-header">{{ group }}</h2>
-                <div class="versions">
+                <div class="versions {% if not loop.last %}versions-separator{% endif %}">
                   {% for version in versions %}
                     <div class="version">{{ version }}</div>
                   {% endfor %}

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -45,7 +45,7 @@
   <spicy-sections
       class="vulnerability-packages{% if vulnerability.affected|should_collapse %} force-collapse{% endif %}">
     {% for affected in vulnerability.affected %}
-      <h2>
+      <h2 class="package-header">
         <span class="vuln-ecosystem spicy-sections-workaround">{{ affected['package']['ecosystem'] }}</span>
         <span class="vuln-title-divider spicy-sections-workaround">/</span>
         <span class="vuln-name spicy-sections-workaround">{{ affected['package']['name'] }}</span>
@@ -93,9 +93,16 @@
             Affected versions
             <a href="https://ossf.github.io/osv-schema/#affectedversions-field"></a>
           </h3>
-          <div class="mdc-layout-grid__cell--span-9 version-value versions">
-            {% for version in affected['versions'] %}
-              <div class="version">{{ version }}</div>
+          <div class="mdc-layout-grid__cell--span-9 version-value">
+            {% for group, versions in (affected['versions']|group_versions).items() %}
+              <spicy-sections class="versions-section">
+                <h2 class="version-header">{{ group }}</h2>
+                <div class="versions">
+                  {% for version in versions %}
+                    <div class="version">{{ version }}</div>
+                  {% endfor %}
+                </div>
+              </spicy-sections>
             {% endfor %}
           </div>
         </div>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -93,9 +93,9 @@
             Affected versions
             <a href="https://ossf.github.io/osv-schema/#affectedversions-field"></a>
           </h3>
-          <div class="mdc-layout-grid__cell--span-9 version-value">
+          <div class="mdc-layout-grid__cell--span-9 version-value versions">
             {% for version in affected['versions'] %}
-              {{ version }}
+              <div class="version">{{ version }}</div>
             {% endfor %}
           </div>
         </div>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -344,6 +344,22 @@ def should_collapse(affected):
   return total_package_length > 70 or len(affected) > 5
 
 
+@blueprint.app_template_filter('group_versions')
+def group_versions(versions):
+  """Group versions by prefix."""
+  groups = {}
+
+  for version in sorted(versions):
+    if '.' not in version:
+      groups.setdefault('Other', []).append(version)
+      continue
+
+    label = version.split('.')[0] + '.*'
+    groups.setdefault(label, []).append(version)
+
+  return groups
+
+
 @blueprint.app_template_filter('log')
 def logarithm(n):
   return math.log(n)


### PR DESCRIPTION
- Implement grouped versions (fixes #395).
- Set max width of vulnerability description to 1000px to
  avoid overly wide text on wide screens.
- Align affected versions.
- Fix font for vulnerability package section headings
- Increase spacing between vulnerability details items.

Before: 

![image](https://user-images.githubusercontent.com/759062/162372694-5c968a41-50b8-485d-bb44-a60ccaa6f801.png)

After:

![image](https://user-images.githubusercontent.com/759062/162380277-9af2f6a3-8ee9-4e2d-af30-c24728f10fa5.png)

