### PR TITLE
Allow ecosystem bubbles on homepage to overflow horizontally

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -642,14 +642,13 @@ dl.vulnerability-details,
     margin-bottom: 24px;
   }
 
-  .ecosystem-counts {
+  .ecosystems-section {
     margin-top: 100px;
 
-    .ecosystems {
+    .ecosystem-counts-wrapper {
       @include full-width;
-      display: grid;
-      margin-top: 20px;
-      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+      position: relative;
+      background: #333;
 
       .ecosystems-line-mid,
       .ecosystems-line-0,
@@ -677,6 +676,19 @@ dl.vulnerability-details,
       .ecosystems-line-3 {
         top: 207px;
       }
+    }
+
+    .ecosystem-counts {
+      display: grid;
+      margin-top: 20px;
+      grid-column-gap: 4px;
+      // Indeterminate number of columns of minimum 80px width.
+      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+      // Force columns outside of available space to overflow.
+      // These do not use the value set in grid-template-columns, so set it.
+      overflow-x: auto;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(80px, 1fr);
 
       .ecosystem {
         text-align: center;
@@ -684,7 +696,6 @@ dl.vulnerability-details,
       }
       dd {
         position: relative;
-        background: #333;
         height: 210px;
       }
       .ecosystem-count {

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -648,9 +648,9 @@ dl.vulnerability-details,
     margin-top: 100px;
 
     .ecosystem-counts-wrapper {
-      @include full-width;
       position: relative;
       background: #333;
+      margin-top: 20px;
       height: $ecosystem-count-wrapper-height;
 
       .ecosystems-line-mid,
@@ -683,7 +683,6 @@ dl.vulnerability-details,
 
     .ecosystem-counts {
       display: grid;
-      margin-top: 20px;
       grid-template-rows: $ecosystem-name-height $ecosystem-count-wrapper-height;
       grid-column-gap: 4px;
       // Indeterminate number of columns of minimum 80px width.

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -408,7 +408,7 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
     font-size: $osv-heading-size;
   }
 
-  @media (max-width: 500px) {
+  @media (max-width: $osv-mobile-breakpoint) {
     .title {
       font-size: $osv-heading-size-mobile;
     }
@@ -463,8 +463,8 @@ dl.vulnerability-details,
 
   // Tab bar styling.
   --const-mq-affordances:
-    [screen and (max-width: 500px) ] collapse |
-    [screen and (min-width: 501px) ] tab-bar;
+    [screen and (max-width: #{$osv-mobile-breakpoint}) ] collapse |
+    [screen and (min-width: #{$osv-mobile-breakpoint+1}) ] tab-bar;
 
   .force-collapse {
     --const-mq-affordances: [screen] collapse;
@@ -626,7 +626,7 @@ dl.vulnerability-details,
     margin-bottom: 12px;
   }
 
-  @media (max-width: 500px) {
+  @media (max-width: $osv-mobile-breakpoint) {
     .title {
       font-size: $osv-heading-size-mobile;
       line-height: $osv-heading-line-height-mobile;
@@ -734,7 +734,7 @@ dl.vulnerability-details,
       margin-bottom: 32px;
     }
 
-    @media (max-width: 500px) {
+    @media (max-width: $osv-mobile-breakpoint) {
       .heading {
         font-size: $osv-heading-size-mobile;
       }
@@ -769,7 +769,7 @@ dl.vulnerability-details,
       margin-bottom: 32px;
     }
 
-    @media (max-width: 500px) {
+    @media (max-width: $osv-mobile-breakpoint) {
       .heading {
         font-size: $osv-heading-size-mobile;
       }
@@ -835,7 +835,7 @@ dl.vulnerability-details,
       margin-bottom: 32px;
     }
 
-    @media (max-width: 500px) {
+    @media (max-width: $osv-mobile-breakpoint) {
       .heading {
         font-size: $osv-heading-size-mobile;
       }

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -643,12 +643,15 @@ dl.vulnerability-details,
   }
 
   .ecosystems-section {
+    $ecosystem-name-height: 30px;
+    $ecosystem-count-wrapper-height: 210px;
     margin-top: 100px;
 
     .ecosystem-counts-wrapper {
       @include full-width;
       position: relative;
       background: #333;
+      height: $ecosystem-count-wrapper-height;
 
       .ecosystems-line-mid,
       .ecosystems-line-0,
@@ -681,6 +684,7 @@ dl.vulnerability-details,
     .ecosystem-counts {
       display: grid;
       margin-top: 20px;
+      grid-template-rows: $ecosystem-name-height $ecosystem-count-wrapper-height;
       grid-column-gap: 4px;
       // Indeterminate number of columns of minimum 80px width.
       grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
@@ -690,13 +694,19 @@ dl.vulnerability-details,
       grid-auto-flow: column;
       grid-auto-columns: minmax(80px, 1fr);
 
-      .ecosystem {
+      .ecosystem-name {
+        position: relative;
+        top: $ecosystem-count-wrapper-height;
+        height: $ecosystem-name-height;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         text-align: center;
         font-family: $osv-heading-font-family;
       }
-      dd {
+      .ecosystem-count-wrapper {
         position: relative;
-        height: 210px;
+        top: -$ecosystem-name-height;
       }
       .ecosystem-count {
         font-family: $osv-heading-font-family;

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -646,8 +646,38 @@ dl.vulnerability-details,
     margin-top: 100px;
 
     .ecosystems {
+      @include full-width;
       display: grid;
+      margin-top: 20px;
       grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+
+      .ecosystems-line-mid,
+      .ecosystems-line-0,
+      .ecosystems-line-1,
+      .ecosystems-line-2,
+      .ecosystems-line-3 {
+        width: 100%;
+        border-top: 1px dashed #a0a0a0;
+        position: absolute;
+        z-index: 1;
+      }
+      .ecosystems-line-mid {
+        top: 105px;
+        border-top-style: solid;
+      }
+      .ecosystems-line-0 {
+        top: 0px;
+      }
+      .ecosystems-line-1 {
+        top: 52px;
+      }
+      .ecosystems-line-2 {
+        top: 157px;
+      }
+      .ecosystems-line-3 {
+        top: 207px;
+      }
+
       .ecosystem {
         text-align: center;
         font-family: $osv-heading-font-family;
@@ -670,39 +700,6 @@ dl.vulnerability-details,
         text-align: center;
         z-index: 1;
       }
-    }
-
-    .ecosystems-line {
-      width: 100%;
-      border-top: 1px dashed #a0a0a0;
-      position: relative;
-      z-index: 1;
-    }
-
-    .ecosystems-line-mid {
-      @extend .ecosystems-line;
-      top: 105px;
-      border-top: 1px solid #a0a0a0;
-    }
-
-    .ecosystems-line-0 {
-      @extend .ecosystems-line;
-      top: 0px;
-    }
-
-    .ecosystems-line-1 {
-      @extend .ecosystems-line;
-      top: 52px;
-    }
-
-    .ecosystems-line-2 {
-      @extend .ecosystems-line;
-      top: 157px;
-    }
-
-    .ecosystems-line-3 {
-      @extend .ecosystems-line;
-      top: 207px;
     }
   }
 

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -17,16 +17,16 @@
     <div class="mdc-layout-grid__cell--span-12 ecosystem-counts">
       <h2 class="heading">Ecosystems</h2>
       <dl class="ecosystems">
+        <div class="ecosystems-line-mid"></div>
+        <div class="ecosystems-line-0"></div>
+        <div class="ecosystems-line-1"></div>
+        <div class="ecosystems-line-2"></div>
+        <div class="ecosystems-line-3"></div>
         {% if ecosystem_counts %}
           {% set total = ecosystem_counts.values() | sum %}
           {% for ecosystem in ecosystem_counts %}
             {% if ecosystem_counts[ecosystem] > 30 %}
               <dd>
-              <div class="ecosystems-line-mid"></div>
-              <div class="ecosystems-line-0"></div>
-              <div class="ecosystems-line-1"></div>
-              <div class="ecosystems-line-2"></div>
-              <div class="ecosystems-line-3"></div>
                 {% set radius = [(ecosystem_counts[ecosystem] | log) / (total | log) * 100, 30] | max %}
                 <p class="ecosystem">{{ ecosystem }}</p>
                 <span class="ecosystem-count" style="

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -14,30 +14,32 @@
         <a class="cta-primary link-button" href="#use-the-api">Use the API</a>
       </div>
     </div>
-    <div class="mdc-layout-grid__cell--span-12 ecosystem-counts">
+    <div class="mdc-layout-grid__cell--span-12 ecosystems-section">
       <h2 class="heading">Ecosystems</h2>
-      <dl class="ecosystems">
+      <div class="ecosystem-counts-wrapper">
         <div class="ecosystems-line-mid"></div>
         <div class="ecosystems-line-0"></div>
         <div class="ecosystems-line-1"></div>
         <div class="ecosystems-line-2"></div>
         <div class="ecosystems-line-3"></div>
-        {% if ecosystem_counts %}
-          {% set total = ecosystem_counts.values() | sum %}
-          {% for ecosystem in ecosystem_counts %}
-            {% if ecosystem_counts[ecosystem] > 30 %}
-              <dd>
-                {% set radius = [(ecosystem_counts[ecosystem] | log) / (total | log) * 100, 30] | max %}
-                <p class="ecosystem">{{ ecosystem }}</p>
-                <span class="ecosystem-count" style="
-                   width: {{ radius }}px; height: {{ radius }}px; line-height: {{ radius }}px">
-                  {{ ecosystem_counts[ecosystem] }}
-                </span>
-              </dd>
-            {% endif %}
-          {% endfor %}
-        {% endif %}
-      </dl>
+        <dl class="ecosystem-counts">
+          {% if ecosystem_counts %}
+            {% set total = ecosystem_counts.values() | sum %}
+            {% for ecosystem in ecosystem_counts %}
+              {% if ecosystem_counts[ecosystem] > 30 %}
+                <dd>
+                  {% set radius = [(ecosystem_counts[ecosystem] | log) / (total | log) * 100, 30] | max %}
+                  <p class="ecosystem">{{ ecosystem }}</p>
+                  <span class="ecosystem-count" style="
+                    width: {{ radius }}px; height: {{ radius }}px; line-height: {{ radius }}px">
+                    {{ ecosystem_counts[ecosystem] }}
+                  </span>
+                </dd>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        </dl>
+      </div>
     </div>
 
     <div class="mdc-layout-grid__cell--span-12 text-info">

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -27,9 +27,9 @@
             {% set total = ecosystem_counts.values() | sum %}
             {% for ecosystem in ecosystem_counts %}
               {% if ecosystem_counts[ecosystem] > 30 %}
-                <dd>
+                <dt class="ecosystem-name">{{ ecosystem }}</dt>
+                <dd class="ecosystem-count-wrapper">
                   {% set radius = [(ecosystem_counts[ecosystem] | log) / (total | log) * 100, 30] | max %}
-                  <p class="ecosystem">{{ ecosystem }}</p>
                   <span class="ecosystem-count" style="
                     width: {{ radius }}px; height: {{ radius }}px; line-height: {{ radius }}px">
                     {{ ecosystem_counts[ecosystem] }}


### PR DESCRIPTION
You need to have a small enough screen width for the ecosystems to overflow, which is more likely on touch devices where the scrollbar isn't visually jarring and it's more obvious that cut-off items can be scrolled.

Also updated styling to more closely match mocks.

Fixes #387

![AmepCoXoERs4WpT](https://user-images.githubusercontent.com/79461/162962425-83969cbf-358e-4c9d-be82-3e38b6c80b80.png)

