### PR TITLE
Remove unused "log" package from osv.go

### DIFF
--- a/tools/osv-scanner/internal/osv/osv.go
+++ b/tools/osv-scanner/internal/osv/osv.go
@@ -3,7 +3,6 @@ package osv
 import (
 	"bytes"
 	"encoding/json"
-	"log"
 	"net/http"
 )
 


### PR DESCRIPTION
Remove unused "log" package, as go run, etc. throws 'internal/osv/osv.go:6:2: imported and not used: "log"' error.